### PR TITLE
Use React Context for React API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ export default function App() {
   const dialog = useDialog();
   return (
     <main>
-      <Dialog.Trigger model={dialog}>Edit profile</Dialog.Trigger>
-      <Dialog.Content model={dialog}>
-        <Dialog.Title model={dialog}>Edit profile</Dialog.Title>
-        <Dialog.Description model={dialog}>
-          Make changes to your profile here. Click save when you're done
-        </Dialog.Description>
-        <Dialog.Close model={dialog}>Save changes</Dialog.Close>
-      </Dialog.Content>
+      <Dialog.Root model={dialog}>
+        <Dialog.Trigger>Edit profile</Dialog.Trigger>
+        <Dialog.Content>
+          <Dialog.Title>Edit profile</Dialog.Title>
+          <Dialog.Description>
+            Make changes to your profile here. Click save when you're done
+          </Dialog.Description>
+          <Dialog.Close>Save changes</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Root>
     </main>
   );
 }

--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -150,7 +150,9 @@ export class DialogModel extends StateModel<
 		);
 		if (content?.node === undefined) {
 			if (this.debug) {
-				console.error(`#onOpenChangeEffect(), no content submodel with node`);
+				console.error(
+					`#onOpenChangeEffect(true), no content submodel with node`,
+				);
 			}
 			return;
 		}

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Dialog, useDialog} from '../lib/main';
 
 export default function App() {
-	const [open, setOpen] = React.useState(true);
+	const [open, setOpen] = React.useState(false);
 	const dialog = useDialog({
 		open,
 		onOpenChange: setOpen,
@@ -11,26 +11,28 @@ export default function App() {
 	return (
 		<main>
 			<h1>Ally UI React Dialog</h1>
-			<div>
-				<button onClick={() => setOpen((o) => !o)}>Manual toggle</button>
-				<Dialog.Trigger model={dialog}>Edit profile</Dialog.Trigger>
-			</div>
-			<Dialog.Content model={dialog}>
-				<Dialog.Title model={dialog}>Edit profile</Dialog.Title>
-				<Dialog.Description model={dialog}>
-					Make changes to your profile here. Click save when you're done
-				</Dialog.Description>
-				<fieldset>
-					<label htmlFor="name">Name</label>
-					<input id="name" placeholder="Bryan Lee" />
-				</fieldset>
-				<fieldset>
-					<label htmlFor="username">Username</label>
-					<input id="username" placeholder="@bryanmylee" />
-				</fieldset>
-				<Dialog.Close model={dialog}>Save changes</Dialog.Close>
-				<Dialog.Close model={dialog}>x</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<div>
+					<button onClick={() => setOpen((o) => !o)}>Manual toggle</button>
+					<Dialog.Trigger>Edit profile</Dialog.Trigger>
+				</div>
+				<Dialog.Content>
+					<Dialog.Title>Edit profile</Dialog.Title>
+					<Dialog.Description>
+						Make changes to your profile here. Click save when you're done
+					</Dialog.Description>
+					<fieldset>
+						<label htmlFor="name">Name</label>
+						<input id="name" placeholder="Bryan Lee" />
+					</fieldset>
+					<fieldset>
+						<label htmlFor="username">Username</label>
+						<input id="username" placeholder="@bryanmylee" />
+					</fieldset>
+					<Dialog.Close>Save changes</Dialog.Close>
+					<Dialog.Close>x</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</main>
 	);
 }

--- a/packages/dialog/react/lib/DialogDescription.tsx
+++ b/packages/dialog/react/lib/DialogDescription.tsx
@@ -1,33 +1,40 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
+import {useDialogContext} from './DialogRoot';
 
 export interface DialogDescriptionProps
 	extends React.DetailedHTMLProps<
 		React.HTMLAttributes<HTMLParagraphElement>,
 		HTMLParagraphElement
 	> {
-	model: DialogModel;
+	model?: DialogModel;
 }
 
 const DialogDescription = React.forwardRef<HTMLElement, DialogDescriptionProps>(
 	({model, children, ...restProps}, forwardedRef) => {
-		const id = useRunOnce(() => model.init('description'));
+		const resolvedModel = useDialogContext() ?? model;
+		if (resolvedModel === undefined) {
+			throw new Error(
+				'<Dialog.Description /> must have a `model` prop or be a child of `<Dialog.Root/>`',
+			);
+		}
+		const id = useRunOnce(() => resolvedModel.init('description'));
 
 		const bindRef = React.useCallback(
 			(node: HTMLElement | null) => {
 				if (node === null) {
-					model.unbindNode(id);
+					resolvedModel.unbindNode(id);
 				} else {
-					model.bindNode(id, node);
+					resolvedModel.bindNode(id, node);
 				}
 			},
-			[model],
+			[resolvedModel],
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
 		return (
-			<p ref={ref} {...model.submodelDOMAttributes(id)} {...restProps}>
+			<p ref={ref} {...resolvedModel.submodelDOMAttributes(id)} {...restProps}>
 				{children}
 			</p>
 		);

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -1,0 +1,19 @@
+import {type DialogModel} from '@ally-ui/core-dialog';
+import React from 'react';
+
+export interface DialogRootProps extends React.PropsWithChildren {
+	model: DialogModel;
+}
+
+const DialogContext = React.createContext<DialogModel | undefined>(undefined);
+export function useDialogContext() {
+	return React.useContext(DialogContext);
+}
+
+function DialogRoot({model, children}: DialogRootProps) {
+	return (
+		<DialogContext.Provider value={model}>{children}</DialogContext.Provider>
+	);
+}
+
+export default DialogRoot;

--- a/packages/dialog/react/lib/DialogTitle.tsx
+++ b/packages/dialog/react/lib/DialogTitle.tsx
@@ -1,33 +1,40 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
+import {useDialogContext} from './DialogRoot';
 
 export interface DialogTitleProps
 	extends React.DetailedHTMLProps<
 		React.HTMLAttributes<HTMLHeadingElement>,
 		HTMLHeadingElement
 	> {
-	model: DialogModel;
+	model?: DialogModel;
 }
 
 const DialogTitle = React.forwardRef<HTMLElement, DialogTitleProps>(
 	({model, children, ...restProps}, forwardedRef) => {
-		const id = useRunOnce(() => model.init('title'));
+		const resolvedModel = useDialogContext() ?? model;
+		if (resolvedModel === undefined) {
+			throw new Error(
+				'<Dialog.Title /> must have a `model` prop or be a child of `<Dialog.Root/>`',
+			);
+		}
+		const id = useRunOnce(() => resolvedModel.init('title'));
 
 		const bindRef = React.useCallback(
 			(node: HTMLElement | null) => {
 				if (node === null) {
-					model.unbindNode(id);
+					resolvedModel.unbindNode(id);
 				} else {
-					model.bindNode(id, node);
+					resolvedModel.bindNode(id, node);
 				}
 			},
-			[model],
+			[resolvedModel],
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
 		return (
-			<h1 ref={ref} {...model.submodelDOMAttributes(id)} {...restProps}>
+			<h1 ref={ref} {...resolvedModel.submodelDOMAttributes(id)} {...restProps}>
 				{children}
 			</h1>
 		);

--- a/packages/dialog/react/lib/DialogTrigger.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.tsx
@@ -1,28 +1,35 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
+import {useDialogContext} from './DialogRoot';
 
 export interface DialogTriggerProps
 	extends React.DetailedHTMLProps<
 		React.ButtonHTMLAttributes<HTMLButtonElement>,
 		HTMLButtonElement
 	> {
-	model: DialogModel;
+	model?: DialogModel;
 }
 
 const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 	({model, children, onClick, ...restProps}, forwardedRef) => {
-		const id = useRunOnce(() => model.init('trigger'));
+		const resolvedModel = useDialogContext() ?? model;
+		if (resolvedModel === undefined) {
+			throw new Error(
+				'<Dialog.Trigger /> must have a `model` prop or be a child of `<Dialog.Root/>`',
+			);
+		}
+		const id = useRunOnce(() => resolvedModel.init('trigger'));
 
 		const bindRef = React.useCallback(
 			(node: HTMLElement | null) => {
 				if (node === null) {
-					model.unbindNode(id);
+					resolvedModel.unbindNode(id);
 				} else {
-					model.bindNode(id, node);
+					resolvedModel.bindNode(id, node);
 				}
 			},
-			[model],
+			[resolvedModel],
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
@@ -31,15 +38,15 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 		>(
 			(ev) => {
 				onClick?.(ev);
-				model.setState((prevState) => ({...prevState, open: true}));
+				resolvedModel.setState((prevState) => ({...prevState, open: true}));
 			},
-			[model],
+			[resolvedModel],
 		);
 
 		return (
 			<button
 				ref={ref}
-				{...model.submodelDOMAttributes(id)}
+				{...resolvedModel.submodelDOMAttributes(id)}
 				{...restProps}
 				onClick={handleClick}
 			>

--- a/packages/dialog/react/lib/__tests__/attributes.test.tsx
+++ b/packages/dialog/react/lib/__tests__/attributes.test.tsx
@@ -7,20 +7,16 @@ function Attributes(options: UseDialogOptions) {
 	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/__tests__/focus/Focus.tsx
+++ b/packages/dialog/react/lib/__tests__/focus/Focus.tsx
@@ -6,20 +6,16 @@ export default function Focus(options: UseDialogOptions) {
 	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/__tests__/initialization.test.tsx
+++ b/packages/dialog/react/lib/__tests__/initialization.test.tsx
@@ -7,20 +7,16 @@ function Initialization(options: UseDialogOptions) {
 	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/__tests__/ssr/attributes.test.tsx
+++ b/packages/dialog/react/lib/__tests__/ssr/attributes.test.tsx
@@ -11,20 +11,16 @@ function RenderedOpen() {
 	const dialog = useDialog({initialOpen: true});
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }
@@ -34,20 +30,16 @@ export function RenderedClosed() {
 	const dialog = useDialog();
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/__tests__/ssr/initialization.test.tsx
+++ b/packages/dialog/react/lib/__tests__/ssr/initialization.test.tsx
@@ -11,20 +11,16 @@ function RenderedOpen() {
 	const dialog = useDialog({initialOpen: true});
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }
@@ -34,20 +30,16 @@ export function RenderedClosed() {
 	const dialog = useDialog();
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/__tests__/toggle/Toggle.tsx
+++ b/packages/dialog/react/lib/__tests__/toggle/Toggle.tsx
@@ -6,20 +6,16 @@ export default function Toggle(options: UseDialogOptions) {
 	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Trigger model={dialog} data-testid="trigger">
-				open dialog
-			</Dialog.Trigger>
-			<Dialog.Content model={dialog} data-testid="content">
-				<Dialog.Title model={dialog} data-testid="title">
-					title
-				</Dialog.Title>
-				<Dialog.Description model={dialog} data-testid="description">
-					description
-				</Dialog.Description>
-				<Dialog.Close model={dialog} data-testid="close">
-					close dialog
-				</Dialog.Close>
-			</Dialog.Content>
+			<Dialog.Root model={dialog}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content">
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
 		</React.StrictMode>
 	);
 }

--- a/packages/dialog/react/lib/main.ts
+++ b/packages/dialog/react/lib/main.ts
@@ -1,9 +1,12 @@
 import Close from './DialogClose';
 import Content from './DialogContent';
 import Description from './DialogDescription';
+import Root from './DialogRoot';
 import Title from './DialogTitle';
 import Trigger from './DialogTrigger';
+
 export const Dialog = {
+	Root,
 	Close,
 	Content,
 	Description,

--- a/packages/dialog/react/lib/useDialog.tsx
+++ b/packages/dialog/react/lib/useDialog.tsx
@@ -35,7 +35,9 @@ export default function useDialog(
 	}));
 
 	const flushDOM = useLayoutPromise([state]);
-	model.setUIOptions({flushDOM});
+	model.setUIOptions({
+		flushDOM,
+	});
 
 	return model;
 }


### PR DESCRIPTION
By providing a `Dialog.Root` component, we can get rid of all passing `model` into each subcomponent directly.

However, due to how `flushDOM` is implemented, we still have to call the `useDialog` hook above the `Dialog.Root` component.

```tsx
export default function App() {
  const dialog = useDialog();
  return (
    <main>
      <Dialog.Root model={dialog}>
        <Dialog.Trigger>Edit profile</Dialog.Trigger>
        <Dialog.Content>
          <Dialog.Title>Edit profile</Dialog.Title>
          <Dialog.Description>
            Make changes to your profile here. Click save when you're done
          </Dialog.Description>
          <Dialog.Close>Save changes</Dialog.Close>
        </Dialog.Content>
      </Dialog.Root>
    </main>
  );
}
```