### PR TITLE
Remove the need for `useDialog` above `Dialog.Root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ The core of Ally UI is built with plain-old JavaScript and simple bindings are u
 
 ```tsx
 export default function App() {
-  const dialog = useDialog();
   return (
     <main>
-      <Dialog.Root model={dialog}>
+      <Dialog.Root>
         <Dialog.Trigger>Edit profile</Dialog.Trigger>
         <Dialog.Content>
           <Dialog.Title>Edit profile</Dialog.Title>

--- a/packages/common/focus-trap/lib/main.ts
+++ b/packages/common/focus-trap/lib/main.ts
@@ -77,10 +77,42 @@ function getActualTarget(ev: Event) {
 }
 
 export interface FocusTrapOptions {
+	/**
+	 * The container to trap focus within.
+	 */
 	container: HTMLElement;
-	active?: boolean;
+	/**
+	 * Whether the focus trap should initially be active.
+	 *
+	 * Defaults to `false`.
+	 */
+	initialActive?: boolean;
+	/**
+	 * Whether clicking outside the focus trap container deactivates the trap.
+	 *
+	 * Pass a handler function to configure when the trap should deactivate based
+	 * on each individual mouse click.
+	 *
+	 * Defaults to `false`.
+	 */
 	clickOutsideDeactivates?: boolean | ((ev: MouseEvent) => boolean);
+	/**
+	 * Whether pressing escape deactives the trap.
+	 *
+	 * Pass a handler function to configure when the trap should deactivate based
+	 * on each individual keystroke.
+	 *
+	 * Defaults to `false`.
+	 */
 	escapeDeactivates?: boolean | ((ev: KeyboardEvent) => boolean);
+	/**
+	 * A custom element to return focus to on deactivation.
+	 *
+	 * Pass a getter function to dynamically get the element to return focus to
+	 * on deactivation.
+	 *
+	 * Defaults to the previously focused element before the trap activated.
+	 */
 	returnFocusTo?: HTMLElement | (() => HTMLElement | undefined);
 }
 
@@ -101,7 +133,7 @@ export class FocusTrapModel extends StateModel<
 
 	deriveInitialState(options: FocusTrapOptions): FocusTrapState {
 		return {
-			active: options.active ?? false,
+			active: options.initialActive ?? false,
 		};
 	}
 

--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -181,16 +181,16 @@ export class DialogModel extends StateModel<
 
 	#contentTrap?: FocusTrapModel;
 	async #onOpenChangeEffect(open: boolean) {
+		// Flush changes to the DOM before looking for nodes in DOM.
+		await this.uiOptions?.flushDOM?.();
 		if (open) {
-			await this.#onOpenChangeEffect_true();
+			this.#onOpenChangeEffect_true();
 		} else {
 			this.#onOpenChangeEffect_false();
 		}
 	}
 
-	async #onOpenChangeEffect_true() {
-		// Flush changes to the DOM before looking for the content node in DOM.
-		await this.uiOptions?.flushDOM?.();
+	#onOpenChangeEffect_true() {
 		const content = findLastInMap(
 			this.#components,
 			(c) => c.type === 'content' && c.node !== undefined,
@@ -207,14 +207,17 @@ export class DialogModel extends StateModel<
 	}
 
 	#createFocusTrap(contentElement: HTMLElement) {
-		const triggerComponent = findLastInMap(
-			this.#components,
-			(c) => c.type === 'trigger',
-		);
+		const getTriggerNode = () => {
+			const triggerComponent = findLastInMap(
+				this.#components,
+				(c) => c.type === 'trigger',
+			);
+			return triggerComponent?.node;
+		};
 		const contentTrap = new FocusTrapModel(this.id, {
 			container: contentElement,
-			active: true,
-			returnFocusTo: triggerComponent?.node,
+			initialActive: true,
+			returnFocusTo: getTriggerNode,
 		});
 		contentTrap.setUIOptions(this.uiOptions);
 		contentTrap.setOptions((prevOptions) => ({

--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -181,16 +181,16 @@ export class DialogModel extends StateModel<
 
 	#contentTrap?: FocusTrapModel;
 	async #onOpenChangeEffect(open: boolean) {
-		// Flush changes to the DOM before looking for nodes in DOM.
-		await this.uiOptions?.flushDOM?.();
 		if (open) {
-			this.#onOpenChangeEffect_true();
+			await this.#onOpenChangeEffect_true();
 		} else {
-			this.#onOpenChangeEffect_false();
+			await this.#onOpenChangeEffect_false();
 		}
 	}
 
-	#onOpenChangeEffect_true() {
+	async #onOpenChangeEffect_true() {
+		// Flush changes to the DOM before looking for nodes in DOM.
+		await this.uiOptions?.flushDOM?.();
 		const content = findLastInMap(
 			this.#components,
 			(c) => c.type === 'content' && c.node !== undefined,
@@ -238,10 +238,12 @@ export class DialogModel extends StateModel<
 		return contentTrap;
 	}
 
-	#onOpenChangeEffect_false() {
+	async #onOpenChangeEffect_false() {
 		if (this.#contentTrap === undefined) {
 			return;
 		}
+		// Flush changes to the DOM before looking for nodes in DOM.
+		await this.uiOptions?.flushDOM?.();
 		this.#contentTrap.deactivate();
 		this.#contentTrap = undefined;
 	}

--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -138,7 +138,14 @@ export class DialogModel extends StateModel<
 		return `${this.#rootId()}-${type}`;
 	}
 
-	componentAttributes(componentId: string) {
+	/**
+	 * Get the required DOM attributes for a component with a given state.
+	 * @param componentId The component to get attributes for
+	 * @param state If the component attributes are static, this can be omitted.
+	 * @returns An object describing the DOM attributes to apply to the component node
+	 */
+	componentAttributes(componentId: string, state?: DialogModelState) {
+		const resolvedState = state ?? this.getState();
 		const component = this.#components.get(componentId);
 		if (component === undefined) {
 			if (this.debug) {
@@ -154,14 +161,14 @@ export class DialogModel extends StateModel<
 					'aria-modal': 'true',
 					'aria-labelledby': this.#componentId('title'),
 					'aria-describedby': this.#componentId('description'),
-					'data-state': this.getState().open ? 'open' : 'closed',
+					'data-state': resolvedState.open ? 'open' : 'closed',
 				} as const;
 			case 'trigger':
 				return {
 					id: this.#componentId(component.type),
 					'aria-haspopup': 'dialog',
 					'aria-controls': this.#componentId('content'),
-					'data-state': this.getState().open ? 'open' : 'closed',
+					'data-state': resolvedState.open ? 'open' : 'closed',
 				} as const;
 			case 'title':
 			case 'description':

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import {Dialog} from '../lib/main';
 
 export default function App() {
-	const [open, setOpen] = React.useState(false);
+	const [open, setOpen] = React.useState(true);
 
 	return (
 		<main>
 			<h1>Ally UI React Dialog</h1>
-			<Dialog.Root open={open} onOpenChange={setOpen}>
+			<Dialog.Root open={open} onOpenChange={setOpen} initialOpen>
 				<div>
 					<button onClick={() => setOpen((o) => !o)}>Manual toggle</button>
 					<Dialog.Trigger>Edit profile</Dialog.Trigger>

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import {Dialog, useDialog} from '../lib/main';
+import {Dialog} from '../lib/main';
 
 export default function App() {
 	const [open, setOpen] = React.useState(false);
-	const dialog = useDialog({
-		open,
-		onOpenChange: setOpen,
-	});
 
 	return (
 		<main>
 			<h1>Ally UI React Dialog</h1>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root open={open} onOpenChange={setOpen}>
 				<div>
 					<button onClick={() => setOpen((o) => !o)}>Manual toggle</button>
 					<Dialog.Trigger>Edit profile</Dialog.Trigger>

--- a/packages/dialog/react/lib/DialogClose.tsx
+++ b/packages/dialog/react/lib/DialogClose.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogContext} from './DialogRoot';
+import {useDialogModelContext} from './DialogRoot';
 
 export interface DialogCloseProps
 	extends React.DetailedHTMLProps<
@@ -13,7 +13,7 @@ export interface DialogCloseProps
 
 const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
 	({model, children, onClick, ...restProps}, forwardedRef) => {
-		const resolvedModel = useDialogContext() ?? model;
+		const resolvedModel = useDialogModelContext() ?? model;
 		if (resolvedModel === undefined) {
 			throw new Error(
 				'<Dialog.Close /> must have a `model` prop or be a child of `<Dialog.Root/>`',

--- a/packages/dialog/react/lib/DialogContent.tsx
+++ b/packages/dialog/react/lib/DialogContent.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogContext} from './DialogRoot';
+import {useDialogModelContext, useDialogStateContext} from './DialogRoot';
 
 export interface DialogContentProps
 	extends React.DetailedHTMLProps<
@@ -13,13 +13,15 @@ export interface DialogContentProps
 
 const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
 	({model, children, ...restProps}, forwardedRef) => {
-		const resolvedModel = useDialogContext() ?? model;
+		const resolvedModel = useDialogModelContext() ?? model;
 		if (resolvedModel === undefined) {
 			throw new Error(
 				'<Dialog.Content /> must have a `model` prop or be a child of `<Dialog.Root/>`',
 			);
 		}
 		const id = useRunOnce(() => resolvedModel.init('content'));
+
+		const resolvedState = useDialogStateContext() ?? resolvedModel.getState();
 
 		React.useEffect(
 			function mount() {
@@ -45,7 +47,7 @@ const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
 
 		return (
 			<>
-				{resolvedModel.getState().open && (
+				{resolvedState.open && (
 					<div
 						ref={ref}
 						{...resolvedModel.componentAttributes(id)}

--- a/packages/dialog/react/lib/DialogContent.tsx
+++ b/packages/dialog/react/lib/DialogContent.tsx
@@ -50,7 +50,7 @@ const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
 				{resolvedState.open && (
 					<div
 						ref={ref}
-						{...resolvedModel.componentAttributes(id)}
+						{...resolvedModel.componentAttributes(id, resolvedState)}
 						{...restProps}
 					>
 						{children}

--- a/packages/dialog/react/lib/DialogDescription.tsx
+++ b/packages/dialog/react/lib/DialogDescription.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogContext} from './DialogRoot';
+import {useDialogModelContext} from './DialogRoot';
 
 export interface DialogDescriptionProps
 	extends React.DetailedHTMLProps<
@@ -13,7 +13,7 @@ export interface DialogDescriptionProps
 
 const DialogDescription = React.forwardRef<HTMLElement, DialogDescriptionProps>(
 	({model, children, ...restProps}, forwardedRef) => {
-		const resolvedModel = useDialogContext() ?? model;
+		const resolvedModel = useDialogModelContext() ?? model;
 		if (resolvedModel === undefined) {
 			throw new Error(
 				'<Dialog.Description /> must have a `model` prop or be a child of `<Dialog.Root/>`',

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -1,4 +1,4 @@
-import {type DialogModel} from '@ally-ui/core-dialog';
+import {DialogModel, DialogModelState} from '@ally-ui/core-dialog';
 import React from 'react';
 import useDialog, {UseDialogOptions} from './useDialog';
 
@@ -6,19 +6,27 @@ export interface DialogRootProps
 	extends React.PropsWithChildren,
 		UseDialogOptions {}
 
-const DialogContext = React.createContext<DialogModel | undefined>(undefined);
-export function useDialogContext() {
-	return React.useContext(DialogContext);
+const DialogModelContext = React.createContext<DialogModel | undefined>(
+	undefined,
+);
+export function useDialogModelContext() {
+	return React.useContext(DialogModelContext);
+}
+
+const DialogStateContext = React.createContext<DialogModelState | undefined>(
+	undefined,
+);
+export function useDialogStateContext() {
+	return React.useContext(DialogStateContext);
 }
 
 export default function DialogRoot({children, ...options}: DialogRootProps) {
-	const dialog = useDialog(options, {debug: true});
+	const [model, state] = useDialog(options, {debug: true});
 	return (
-		<DialogContext.Provider
-			value={dialog}
-			key={dialog.getState().open ? 'open' : 'closed'}
-		>
-			{children}
-		</DialogContext.Provider>
+		<DialogModelContext.Provider value={model}>
+			<DialogStateContext.Provider value={state}>
+				{children}
+			</DialogStateContext.Provider>
+		</DialogModelContext.Provider>
 	);
 }

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -22,6 +22,7 @@ export function useDialogStateContext() {
 
 export default function DialogRoot({children, ...options}: DialogRootProps) {
 	const [model, state] = useDialog(options, {debug: true});
+	// TODO Avoid nesting context providers.
 	return (
 		<DialogModelContext.Provider value={model}>
 			<DialogStateContext.Provider value={state}>

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -21,7 +21,7 @@ export function useDialogStateContext() {
 }
 
 export default function DialogRoot({children, ...options}: DialogRootProps) {
-	const [model, state] = useDialog(options, {debug: true});
+	const [model, state] = useDialog(options);
 	// TODO Avoid nesting context providers.
 	return (
 		<DialogModelContext.Provider value={model}>

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -1,19 +1,24 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import React from 'react';
+import useDialog, {UseDialogOptions} from './useDialog';
 
-export interface DialogRootProps extends React.PropsWithChildren {
-	model: DialogModel;
-}
+export interface DialogRootProps
+	extends React.PropsWithChildren,
+		UseDialogOptions {}
 
 const DialogContext = React.createContext<DialogModel | undefined>(undefined);
 export function useDialogContext() {
 	return React.useContext(DialogContext);
 }
 
-function DialogRoot({model, children}: DialogRootProps) {
+export default function DialogRoot({children, ...options}: DialogRootProps) {
+	const dialog = useDialog(options, {debug: true});
 	return (
-		<DialogContext.Provider value={model}>{children}</DialogContext.Provider>
+		<DialogContext.Provider
+			value={dialog}
+			key={dialog.getState().open ? 'open' : 'closed'}
+		>
+			{children}
+		</DialogContext.Provider>
 	);
 }
-
-export default DialogRoot;

--- a/packages/dialog/react/lib/DialogTitle.tsx
+++ b/packages/dialog/react/lib/DialogTitle.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogContext} from './DialogRoot';
+import {useDialogModelContext} from './DialogRoot';
 
 export interface DialogTitleProps
 	extends React.DetailedHTMLProps<
@@ -13,7 +13,7 @@ export interface DialogTitleProps
 
 const DialogTitle = React.forwardRef<HTMLElement, DialogTitleProps>(
 	({model, children, ...restProps}, forwardedRef) => {
-		const resolvedModel = useDialogContext() ?? model;
+		const resolvedModel = useDialogModelContext() ?? model;
 		if (resolvedModel === undefined) {
 			throw new Error(
 				'<Dialog.Title /> must have a `model` prop or be a child of `<Dialog.Root/>`',

--- a/packages/dialog/react/lib/DialogTrigger.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogContext} from './DialogRoot';
+import {useDialogModelContext} from './DialogRoot';
 
 export interface DialogTriggerProps
 	extends React.DetailedHTMLProps<
@@ -13,7 +13,7 @@ export interface DialogTriggerProps
 
 const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 	({model, children, onClick, ...restProps}, forwardedRef) => {
-		const resolvedModel = useDialogContext() ?? model;
+		const resolvedModel = useDialogModelContext() ?? model;
 		if (resolvedModel === undefined) {
 			throw new Error(
 				'<Dialog.Trigger /> must have a `model` prop or be a child of `<Dialog.Root/>`',

--- a/packages/dialog/react/lib/DialogTrigger.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.tsx
@@ -1,7 +1,7 @@
 import {type DialogModel} from '@ally-ui/core-dialog';
 import {useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
-import {useDialogModelContext} from './DialogRoot';
+import {useDialogModelContext, useDialogStateContext} from './DialogRoot';
 
 export interface DialogTriggerProps
 	extends React.DetailedHTMLProps<
@@ -20,6 +20,8 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 			);
 		}
 		const id = useRunOnce(() => resolvedModel.init('trigger'));
+
+		const resolvedState = useDialogStateContext() ?? resolvedModel.getState();
 
 		React.useEffect(
 			function mount() {
@@ -56,7 +58,7 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 		return (
 			<button
 				ref={ref}
-				{...resolvedModel.componentAttributes(id)}
+				{...resolvedModel.componentAttributes(id, resolvedState)}
 				{...restProps}
 				onClick={handleClick}
 			>

--- a/packages/dialog/react/lib/__tests__/attributes.test.tsx
+++ b/packages/dialog/react/lib/__tests__/attributes.test.tsx
@@ -1,13 +1,12 @@
 import {cleanup, render, screen} from '@testing-library/react';
 import React from 'react';
-import {Dialog, useDialog} from '../main';
+import {Dialog} from '../main';
 import {UseDialogOptions} from '../useDialog';
 
 function Attributes(options: UseDialogOptions) {
-	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root {...options}>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/focus/Focus.tsx
+++ b/packages/dialog/react/lib/__tests__/focus/Focus.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import {Dialog, useDialog} from '../../main';
+import {Dialog} from '../../main';
 import {UseDialogOptions} from '../../useDialog';
 
 export default function Focus(options: UseDialogOptions) {
-	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root {...options}>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/focus/return-focus-to-trigger.test.tsx
+++ b/packages/dialog/react/lib/__tests__/focus/return-focus-to-trigger.test.tsx
@@ -6,9 +6,9 @@ afterEach(async () => {
 	cleanup();
 });
 
-it('traps focus on tab', async () => {
+it('returns focus to the trigger on deactivation', async () => {
 	const user = userEvent.setup();
 	render(<Focus initialOpen />);
 	await user.click(await screen.findByTestId('close'));
-	expect(screen.getByTestId('trigger')).toHaveFocusWithin();
+	expect(screen.getByTestId('trigger')).toHaveFocus();
 });

--- a/packages/dialog/react/lib/__tests__/initialization.test.tsx
+++ b/packages/dialog/react/lib/__tests__/initialization.test.tsx
@@ -1,13 +1,12 @@
 import {cleanup, render, screen} from '@testing-library/react';
 import React from 'react';
-import {Dialog, useDialog} from '../main';
+import {Dialog} from '../main';
 import {UseDialogOptions} from '../useDialog';
 
 function Initialization(options: UseDialogOptions) {
-	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root {...options}>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/ssr/attributes.test.tsx
+++ b/packages/dialog/react/lib/__tests__/ssr/attributes.test.tsx
@@ -1,17 +1,16 @@
 import {screen} from '@testing-library/dom';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import {Dialog, useDialog} from '../../main';
+import {Dialog} from '../../main';
 
 afterEach(() => {
 	document.body.innerHTML = '';
 });
 
 function RenderedOpen() {
-	const dialog = useDialog({initialOpen: true});
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root initialOpen>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>
@@ -27,10 +26,9 @@ function RenderedOpen() {
 const rendered_open = ReactDOMServer.renderToString(<RenderedOpen />);
 
 export function RenderedClosed() {
-	const dialog = useDialog();
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/ssr/initialization.test.tsx
+++ b/packages/dialog/react/lib/__tests__/ssr/initialization.test.tsx
@@ -1,17 +1,16 @@
 import {screen} from '@testing-library/dom';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import {Dialog, useDialog} from '../../main';
+import {Dialog} from '../../main';
 
 afterEach(() => {
 	document.body.innerHTML = '';
 });
 
 function RenderedOpen() {
-	const dialog = useDialog({initialOpen: true});
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root initialOpen>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>
@@ -27,10 +26,9 @@ function RenderedOpen() {
 const rendered_open = ReactDOMServer.renderToString(<RenderedOpen />);
 
 export function RenderedClosed() {
-	const dialog = useDialog();
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/toggle/Toggle.tsx
+++ b/packages/dialog/react/lib/__tests__/toggle/Toggle.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import {Dialog, useDialog} from '../../main';
+import {Dialog} from '../../main';
 import {UseDialogOptions} from '../../useDialog';
 
 export default function Toggle(options: UseDialogOptions) {
-	const dialog = useDialog(options);
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root {...options}>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/react/lib/__tests__/toggle/trigger-data-state-attribute.test.tsx
+++ b/packages/dialog/react/lib/__tests__/toggle/trigger-data-state-attribute.test.tsx
@@ -4,10 +4,25 @@ import Toggle from './Toggle';
 
 it('updates the data state attribute when the dialog opens and closes', async () => {
 	const user = userEvent.setup();
-	render(<Toggle initialOpen />);
+	render(<Toggle />);
 	const trigger = await screen.findByTestId('trigger');
+
+	await user.click(trigger);
+	await screen.findByTestId('title');
+	expect(trigger).toHaveAttribute('data-state', 'open');
+
 	await user.click(await screen.findByTestId('close'));
 	expect(trigger).toHaveAttribute('data-state', 'closed');
+});
+
+it('updates the data state attribute when the dialog closes and opens', async () => {
+	const user = userEvent.setup();
+	render(<Toggle initialOpen />);
+	const trigger = await screen.findByTestId('trigger');
+
+	await user.click(await screen.findByTestId('close'));
+	expect(trigger).toHaveAttribute('data-state', 'closed');
+
 	await user.click(trigger);
 	await screen.findByTestId('title');
 	expect(trigger).toHaveAttribute('data-state', 'open');

--- a/packages/dialog/react/lib/__tests__/warnings/missing-title.test.tsx
+++ b/packages/dialog/react/lib/__tests__/warnings/missing-title.test.tsx
@@ -1,13 +1,12 @@
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
 import {vi} from 'vitest';
-import {Dialog, useDialog} from '../../main';
+import {Dialog} from '../../main';
 
 function MissingTitle() {
-	const dialog = useDialog({initialOpen: true});
 	return (
 		<React.StrictMode>
-			<Dialog.Root model={dialog}>
+			<Dialog.Root initialOpen>
 				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 				<Dialog.Content data-testid="content">
 					<Dialog.Description data-testid="description">

--- a/packages/dialog/react/lib/useDialog.tsx
+++ b/packages/dialog/react/lib/useDialog.tsx
@@ -1,5 +1,9 @@
 import {DevOptions} from '@ally-ui/core';
-import {DialogModel, DialogModelOptions} from '@ally-ui/core-dialog';
+import {
+	DialogModel,
+	DialogModelOptions,
+	DialogModelState,
+} from '@ally-ui/core-dialog';
 import {useLayoutPromise, useRunOnce, useSyncOption} from '@ally-ui/react';
 import React from 'react';
 
@@ -8,10 +12,12 @@ export interface UseDialogOptions extends DialogModelOptions {
 	onOpenChange?: (open: boolean) => void;
 }
 
+export type UseDialogValue = [DialogModel, DialogModelState];
+
 export default function useDialog(
 	{initialOpen, onOpenChange, open}: UseDialogOptions = {},
 	devOptions: DevOptions = {},
-): DialogModel {
+): UseDialogValue {
 	const id = React.useId();
 	const model = useRunOnce(
 		() => new DialogModel(id, {initialOpen}, devOptions),
@@ -39,5 +45,5 @@ export default function useDialog(
 		flushDOM,
 	});
 
-	return model;
+	return [model, state];
 }

--- a/packages/dialog/svelte/lib/__tests__/focus/return-focus-to-trigger.test.ts
+++ b/packages/dialog/svelte/lib/__tests__/focus/return-focus-to-trigger.test.ts
@@ -6,7 +6,7 @@ afterEach(async () => {
 	cleanup();
 });
 
-it('traps focus on tab', async () => {
+it('returns focus to the trigger on deactivation', async () => {
 	const user = userEvent.setup();
 	render(Focus, {initialOpen: true});
 	await user.click(screen.getByTestId('close'));

--- a/packages/dialog/svelte/lib/__tests__/toggle/trigger-data-state-attribute.test.ts
+++ b/packages/dialog/svelte/lib/__tests__/toggle/trigger-data-state-attribute.test.ts
@@ -2,7 +2,7 @@ import {render, screen} from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import Toggle from './toggle.test.svelte';
 
-it('updates the data state attribute when the dialog opens and closes', async () => {
+it('updates the data state attribute on the trigger when the dialog opens and closes', async () => {
 	const user = userEvent.setup();
 	render(Toggle, {initialOpen: true});
 	const trigger = await screen.findByTestId('trigger');


### PR DESCRIPTION
Separate the model and dynamic state into separate contexts so dynamic elements within the dialog can react to state changes without a need to re-render the entire component subtree under the `Dialog.Root` element.

We can now simply do:

```tsx
export default function App() {
  return (
    <Dialog.Root>
      <Dialog.Trigger>Edit profile</Dialog.Trigger>
      <Dialog.Content>
        <Dialog.Title>Edit profile</Dialog.Title>
        <Dialog.Description>
          Make changes to your profile here. Click save when you're done
        </Dialog.Description>
        <Dialog.Close>Save changes</Dialog.Close>
      </Dialog.Content>
    </Dialog.Root>
  );
}
```