### PR TITLE
Remove the need for `createDialog` above `Dialog.Root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,8 @@ export default function App() {
 <summary>Svelte</summary>
 
 ```svelte
-<script>
-  const dialog = createDialog();
-</script>
-
 <main>
-  <Dialog.Root model={dialog}>
+  <Dialog.Root>
     <Dialog.Trigger>Edit profile</Dialog.Trigger>
     <Dialog.Content>
       <Dialog.Title>Edit profile</Dialog.Title>

--- a/packages/dialog/svelte/example/App.svelte
+++ b/packages/dialog/svelte/example/App.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import {writable} from 'svelte/store';
-	import {createDialog, Dialog} from '../lib/main';
+	import {Dialog} from '../lib/main';
 
 	const open = writable(false);
-	const dialog = createDialog({open});
 </script>
 
 <main>
 	<h1>Ally UI Svelte Dialog</h1>
-	<Dialog.Root model={dialog}>
+	<Dialog.Root {open}>
 		<div>
 			<button on:click={() => ($open = !$open)}> Manual toggle </button>
 			<Dialog.Trigger>Edit profile</Dialog.Trigger>

--- a/packages/dialog/svelte/lib/DialogRoot.svelte
+++ b/packages/dialog/svelte/lib/DialogRoot.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
-	import type {DialogModel} from '@ally-ui/core-dialog';
-	import type {Readable} from 'svelte/store';
+	import type {ReadOrWritable} from '@ally-ui/svelte';
 	import {setDialogContext} from './context';
+	import type {CreateDialogOptions} from './createDialog';
+	import createDialog from './createDialog';
 
-	export let model: Readable<DialogModel>;
+	interface $$Props extends CreateDialogOptions {}
+	export let open: ReadOrWritable<boolean> | undefined = undefined;
+	export let initialOpen: boolean | undefined = undefined;
+	const model = createDialog({
+		open,
+		initialOpen,
+	});
 	setDialogContext(model);
 </script>
 

--- a/packages/dialog/svelte/lib/__tests__/attributes.test.svelte
+++ b/packages/dialog/svelte/lib/__tests__/attributes.test.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../main';
+	import {Dialog} from '../main';
 
 	export let initialOpen = false;
-	const dialog = createDialog({initialOpen});
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root {initialOpen}>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/focus/focus.test.svelte
+++ b/packages/dialog/svelte/lib/__tests__/focus/focus.test.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../../main';
+	import {Dialog} from '../../main';
 
 	export let initialOpen: boolean;
-	const dialog = createDialog({initialOpen});
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root {initialOpen}>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/initialization.test.svelte
+++ b/packages/dialog/svelte/lib/__tests__/initialization.test.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../main';
+	import {Dialog} from '../main';
 
 	export let initialOpen = false;
-	const dialog = createDialog({initialOpen});
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root {initialOpen}>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/ssr/__tests__/init--closed.svelte
+++ b/packages/dialog/svelte/lib/__tests__/ssr/__tests__/init--closed.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../../../main';
-
-	const dialog = createDialog();
+	import {Dialog} from '../../../main';
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/ssr/__tests__/init--open.svelte
+++ b/packages/dialog/svelte/lib/__tests__/ssr/__tests__/init--open.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../../../main';
-
-	const dialog = createDialog({initialOpen: true});
+	import {Dialog} from '../../../main';
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root initialOpen>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/toggle/toggle.test.svelte
+++ b/packages/dialog/svelte/lib/__tests__/toggle/toggle.test.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import {createDialog, Dialog} from '../../main';
+	import {Dialog} from '../../main';
 
 	export let initialOpen: boolean;
-	const dialog = createDialog({initialOpen});
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root {initialOpen}>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/lib/__tests__/toggle/trigger-data-state-attribute.test.ts
+++ b/packages/dialog/svelte/lib/__tests__/toggle/trigger-data-state-attribute.test.ts
@@ -2,12 +2,27 @@ import {render, screen} from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import Toggle from './toggle.test.svelte';
 
-it('updates the data state attribute on the trigger when the dialog opens and closes', async () => {
+it('updates the data state attribute when the dialog opens and closes', async () => {
+	const user = userEvent.setup();
+	render(Toggle);
+	const trigger = await screen.findByTestId('trigger');
+
+	await user.click(trigger);
+	await screen.findByTestId('title');
+	expect(trigger).toHaveAttribute('data-state', 'open');
+
+	await user.click(await screen.findByTestId('close'));
+	expect(trigger).toHaveAttribute('data-state', 'closed');
+});
+
+it('updates the data state attribute when the dialog closes and opens', async () => {
 	const user = userEvent.setup();
 	render(Toggle, {initialOpen: true});
 	const trigger = await screen.findByTestId('trigger');
+
 	await user.click(await screen.findByTestId('close'));
 	expect(trigger).toHaveAttribute('data-state', 'closed');
+
 	await user.click(trigger);
 	await screen.findByTestId('title');
 	expect(trigger).toHaveAttribute('data-state', 'open');

--- a/packages/dialog/svelte/lib/__tests__/warnings/missing-title.test.svelte
+++ b/packages/dialog/svelte/lib/__tests__/warnings/missing-title.test.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import {createDialog, Dialog} from '../../main';
-
-	const dialog = createDialog({initialOpen: true});
 </script>
 
-<Dialog.Root model={dialog}>
+<Dialog.Root initialOpen>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Description data-testid="description">


### PR DESCRIPTION
Svelte's state management is quite straightforward so there were minimal internal changes required for this change.

We can now simply do:

```svelte
<!-- App.svelte -->
<Dialog.Root>
  <Dialog.Trigger>Edit profile</Dialog.Trigger>
  <Dialog.Content>
    <Dialog.Title>Edit profile</Dialog.Title>
    <Dialog.Description>
      Make changes to your profile here. Click save when you're done
    </Dialog.Description>
    <Dialog.Close>Save changes</Dialog.Close>
  </Dialog.Content>
</Dialog.Root>
```