### PR TITLE
Simplify state model

### DIFF
--- a/packages/common/core/lib/state.ts
+++ b/packages/common/core/lib/state.ts
@@ -2,24 +2,28 @@ import isEqual from 'lodash.isequal';
 import type {UIOptions} from './ui';
 
 export type Updater<TState> = ((oldState: TState) => TState) | TState;
+export type MergeObjects = <TObject>(
+	original: TObject,
+	update: Partial<TObject>,
+) => TObject;
 
 export type ResolvedOptions<TOptions, TState> = TOptions & {
-	/**
-	 * The current state of the model. This should be controlled by the state
-	 * implementation.
-	 */
-	state: TState;
 	/**
 	 * Called by the core model when it **wants** to update state. It is up to
 	 * the state implementation to respond to the state update request and
 	 * trigger any side-effects e.g. updating the DOM.
 	 */
-	onStateChange?: (updater: Updater<TState>) => void;
-};
-
-export interface DevOptions {
+	requestStateUpdate?: (updater: Updater<TState>) => void;
+	/**
+	 * Some UI libraries use proxies for reactivity. We need to handle object
+	 * merging specially in those cases.
+	 */
+	mergeObjects?: MergeObjects;
+	/**
+	 * Determines whether warnings and errors will be logged to console.
+	 */
 	debug?: boolean;
-}
+};
 
 /**
  * A base construct for a stateful model that is decoupled from its state
@@ -31,28 +35,30 @@ export interface DevOptions {
  */
 export abstract class StateModel<TOptions, TState> {
 	id: string;
+
 	initialState: TState;
 	#previousState: TState;
-	options: ResolvedOptions<TOptions, TState>;
-
 	/**
-	 * Determines whether warnings and errors will be logged to console.
+	 * The current state of the model. This should be controlled by the state
+	 * implementation.
 	 */
-	debug: boolean;
+	#state: TState;
+
+	options: ResolvedOptions<TOptions, TState>;
 
 	constructor(
 		id: string,
-		initialOptions: TOptions,
-		{debug = false}: DevOptions = {},
+		/**
+		 * We receive the fully-resolved options during initialization to support
+		 * custom object merge behavior and pass additional configuration options.
+		 */
+		initialOptions: ResolvedOptions<TOptions, TState>,
 	) {
 		this.id = id;
 		this.initialState = this.deriveInitialState(initialOptions);
 		this.#previousState = this.initialState;
-		this.options = {
-			state: this.initialState,
-			...initialOptions,
-		};
-		this.debug = debug;
+		this.#state = this.initialState;
+		this.options = initialOptions;
 	}
 
 	abstract deriveInitialState(options: TOptions): TState;
@@ -63,26 +69,32 @@ export abstract class StateModel<TOptions, TState> {
 		} else {
 			this.options = updater;
 		}
-		if (!isEqual(this.getState(), this.#previousState)) {
-			this.watchStateChange?.(this.getState(), this.#previousState);
-		}
-		this.#previousState = this.getState();
 	}
 
 	getState(): TState {
-		return this.options.state;
+		return this.#state;
 	}
 
-	setState(updater: Updater<TState>) {
-		this.options.onStateChange?.(updater);
+	/**
+	 * Update the model's internal state. This should only be called by the
+	 * external state implementation. Internal state updates should be dispatched
+	 * via `options.requestStateUpdate`.
+	 * @param newState The new state value
+	 */
+	setState(newState: TState) {
+		this.#previousState = this.#state;
+		this.#state = newState;
+		if (!isEqual(newState, this.#previousState)) {
+			this.watchStateChange?.(newState, this.#previousState);
+		}
 	}
 
 	/**
 	 * Watch for changes to state and trigger any effects in the core model.
 	 * @param newState The new state
-	 * @param oldState The previous state
+	 * @param previousState The previous state
 	 */
-	watchStateChange?(newState: TState, oldState: TState): void;
+	watchStateChange?(newState: TState, previousState: TState): void;
 
 	uiOptions?: UIOptions;
 	setUIOptions(uiOptions?: UIOptions) {

--- a/packages/common/core/lib/state.ts
+++ b/packages/common/core/lib/state.ts
@@ -86,7 +86,7 @@ export abstract class StateModel<TOptions, TState> {
 	 *
 	 * Internal state updates should be dispatched via `options.requestStateUpdate`.
 	 *
-	 * @param newState The new state value
+	 * @param newState The new state value.
 	 */
 	setState(newState: TState) {
 		this.#previousState = this.#state;
@@ -98,8 +98,8 @@ export abstract class StateModel<TOptions, TState> {
 
 	/**
 	 * Watch for changes to state and trigger any effects in the core model.
-	 * @param newState The new state
-	 * @param previousState The previous state
+	 * @param newState The new state.
+	 * @param previousState The previous state.
 	 */
 	watchStateChange?(newState: TState, previousState: TState): void;
 

--- a/packages/common/focus-trap/lib/__tests__/observableFocusTrap.ts
+++ b/packages/common/focus-trap/lib/__tests__/observableFocusTrap.ts
@@ -3,8 +3,9 @@ import {FocusTrapModel, FocusTrapOptions, FocusTrapState} from '../main';
 
 /**
  * Use Svelte Stores as the state implementation when testing the focus trap.
- * @param options The options for the focus trap
- * @returns A Readable store containing the trap instance
+ * @param options The options for the focus trap.
+ * @param manualState An optional opt-in to manually control the focus trap.
+ * @returns A Readable store containing the trap instance.
  */
 export function observableFocusTrap(
 	options: FocusTrapOptions,

--- a/packages/common/focus-trap/lib/__tests__/observableFocusTrap.ts
+++ b/packages/common/focus-trap/lib/__tests__/observableFocusTrap.ts
@@ -14,18 +14,19 @@ export function observableFocusTrap(
 
 	const stateStore = manualState ?? writable(trap.initialState);
 
+	trap.setOptions((prevOptions) => ({
+		...prevOptions,
+		requestStateUpdate: (updater) => {
+			if (updater instanceof Function) {
+				stateStore.update(updater);
+			} else {
+				stateStore.set(updater);
+			}
+		},
+	}));
+
 	stateStore.subscribe(($state) => {
-		trap.setOptions((prevOptions) => ({
-			...prevOptions,
-			state: $state,
-			onStateChange: (updater) => {
-				if (updater instanceof Function) {
-					stateStore.update(updater);
-				} else {
-					stateStore.set(updater);
-				}
-			},
-		}));
+		trap.setState($state);
 	});
 
 	return trap;

--- a/packages/common/focus-trap/lib/main.ts
+++ b/packages/common/focus-trap/lib/main.ts
@@ -1,4 +1,4 @@
-import {StateModel} from '@ally-ui/core';
+import {ResolvedOptions, StateModel} from '@ally-ui/core';
 
 function isEscapeEvent(ev: KeyboardEvent) {
 	return ev.key === 'Escape' || ev.key === 'Esc';
@@ -124,7 +124,10 @@ export class FocusTrapModel extends StateModel<
 	FocusTrapOptions,
 	FocusTrapState
 > {
-	constructor(id: string, initialOptions: FocusTrapOptions) {
+	constructor(
+		id: string,
+		initialOptions: ResolvedOptions<FocusTrapOptions, FocusTrapState>,
+	) {
 		super(id, initialOptions);
 		if (this.getState().active) {
 			this.activate();
@@ -327,7 +330,7 @@ export class FocusTrapModel extends StateModel<
 		this.#watchEvents();
 		this.#trapFocus();
 		if (!this.getState().active) {
-			this.options.onStateChange?.((oldState) => ({
+			this.options.requestStateUpdate?.((oldState) => ({
 				...oldState,
 				active: true,
 			}));
@@ -338,7 +341,7 @@ export class FocusTrapModel extends StateModel<
 		this.#unsubscribeChildren?.();
 		this.#unsubscribeEvents?.();
 		if (this.getState().active) {
-			this.options.onStateChange?.((oldState) => ({
+			this.options.requestStateUpdate?.((oldState) => ({
 				...oldState,
 				active: false,
 			}));

--- a/packages/common/focus-trap/lib/main.ts
+++ b/packages/common/focus-trap/lib/main.ts
@@ -28,8 +28,8 @@ function isValueOrHandler<TValue>(
 
 /**
  * Check if a mutation may result in the list of focusable children in the DOM to update
- * @param mutation A DOM mutation observer record
- * @returns If the mutation may update the list of focusable children in the DOM
+ * @param mutation A DOM mutation observer record.
+ * @returns If the mutation may update the list of focusable children in the DOM.
  */
 function mutationUpdatesFocusableChildren(mutation: MutationRecord) {
 	if (mutation.type === 'childList') {
@@ -65,8 +65,8 @@ const FOCUSABLE_SELECTORS = [
  * only works for an _open_ shadow DOM; otherwise, `composedPath()[0] ===
  * event.target` always).
 
- * @param ev The event to find the target of
- * @returns The target of the event
+ * @param ev The event to find the target of.
+ * @returns The target of the event.
  */
 function getActualTarget(ev: Event) {
 	return ev.target instanceof Element &&

--- a/packages/common/react/lib/useLayoutPromise.tsx
+++ b/packages/common/react/lib/useLayoutPromise.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 /**
  * Get a Promise that resolves when the layout effects of some state is committed.
- * @param deps The state to wait on update for
- * @returns A getter of a Promise that resolves when the layout effects of `deps` is committed
+ * @param deps The state to wait on update for.
+ * @returns A getter of a Promise that resolves when the layout effects of `deps` is committed.
  */
 export default function useLayoutPromise(
 	deps: React.DependencyList,

--- a/packages/common/react/lib/useMultipleRefs.tsx
+++ b/packages/common/react/lib/useMultipleRefs.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 /**
  * Handles setting callback refs and MutableRefObjects.
- * @param ref The ref to use for the instance
- * @param instance The instance being set
+ * @param ref The ref to use for the instance.
+ * @param instance The instance being set.
  */
 function setRef<TInstance>(ref: React.Ref<TInstance>, instance: TInstance) {
 	if (ref instanceof Function) {
@@ -21,8 +21,8 @@ function combinedRef<TInstance>(refs: React.Ref<TInstance>[]) {
 // CREDIT https://github.com/radix-ui/primitives/blob/main/packages/react/compose-refs/src/composeRefs.tsx
 /**
  * Create a ref that passes its instance to multiple refs.
- * @param refs The refs that should receive the instance
- * @returns The combined ref
+ * @param refs The refs that should receive the instance.
+ * @returns The combined ref.
  */
 export default function useMultipleRefs<TInstance>(
 	...refs: React.Ref<TInstance>[]

--- a/packages/common/react/lib/useRunOnce.tsx
+++ b/packages/common/react/lib/useRunOnce.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 /**
  * Run a function once **during render**.
- * @param runner The function to run
- * @returns The value returned by `runner`
+ * @param runner The function to run.
+ * @returns The value returned by `runner`.
  */
 export default function useRunOnce<TReturn>(runner: () => TReturn) {
 	const [value] = React.useState(runner);

--- a/packages/common/react/lib/useSyncOption.tsx
+++ b/packages/common/react/lib/useSyncOption.tsx
@@ -2,14 +2,30 @@ import React from 'react';
 import useRunOnce from './useRunOnce';
 
 export interface UseSyncOptionOptions<TOption> {
+	/**
+	 * The external option value.
+	 */
 	option?: TOption;
+	/**
+	 * The internal option value. This should be derived from internal state.
+	 */
 	internal: TOption;
+	/**
+	 * Called with the new external option's value when it changes.
+	 *
+	 * Pass a function to update internal state.
+	 */
 	onOptionChange: React.Dispatch<TOption>;
+	/**
+	 * Called with the new internal option's value when it changes.
+	 *
+	 * Pass a function to update the external option.
+	 */
 	onInternalChange?: React.Dispatch<TOption>;
 }
 
 /**
- * Synchronize state between an externally managed option and internal state.
+ * Synchronize state between an external option and internal state.
  */
 export default function useSyncOption<TOption>({
 	option,

--- a/packages/common/svelte/lib/useSyncOption.ts
+++ b/packages/common/svelte/lib/useSyncOption.ts
@@ -2,7 +2,20 @@ import {get, type Unsubscriber} from 'svelte/store';
 import {isWritable, type ReadOrWritable} from './store';
 
 /**
- * Synchronize state between an externally managed option and internal state.
+ * Synchronize state between an external option and internal state.
+ *
+ * @param option A writable store containing the external option value.
+ * @param onOptionChange Called with the new external option's value when it
+ * changes. Pass a function to update internal state.
+ *
+ * @returns A pair of functions.
+ *
+ * The first function updates the external option and mitigate infinite update
+ * cycles. Call it when internal state updates with the updated value of the
+ * option.
+ *
+ * The second function starts a subscriber on the option store to update
+ * internal state when it updates. It returns an unsubscriber for cleanup.
  */
 export default function useSyncOption<TOption>(
 	option: ReadOrWritable<TOption> | undefined,

--- a/packages/common/svelte/lib/useSyncOption.ts
+++ b/packages/common/svelte/lib/useSyncOption.ts
@@ -10,7 +10,7 @@ import {isWritable, type ReadOrWritable} from './store';
  *
  * @returns A pair of functions.
  *
- * The first function updates the external option and mitigate infinite update
+ * The first function updates the external option and mitigates infinite update
  * cycles. Call it when internal state updates with the updated value of the
  * option.
  *

--- a/packages/common/vue/lib/useSyncOption.ts
+++ b/packages/common/vue/lib/useSyncOption.ts
@@ -9,9 +9,14 @@ export default function useSyncOption<TOption>(
 		onOptionChange(previousOption);
 	}
 	function updateOption(internal: TOption) {
-		if (option !== undefined) {
-			option.value = internal;
+		if (option === undefined) {
+			return;
 		}
+		if (internal === previousOption) {
+			return;
+		}
+		option.value = internal;
+		previousOption = internal;
 	}
 	watchEffect(function updateInternal() {
 		if (option?.value === undefined) {
@@ -21,6 +26,7 @@ export default function useSyncOption<TOption>(
 			return;
 		}
 		onOptionChange(option.value);
+		previousOption = option.value;
 	});
 	return updateOption;
 }

--- a/packages/common/vue/lib/useSyncOption.ts
+++ b/packages/common/vue/lib/useSyncOption.ts
@@ -1,5 +1,15 @@
 import {watchEffect, type Ref} from 'vue';
 
+/**
+ * Synchronize state between an external option and internal state.
+ *
+ * @param option A mutable ref of the external option.
+ * @param onOptionChange Called with the new external option's value when it
+ * changes. Pass a function to update internal state.
+ *
+ * @returns A function to update the external option and mitigate infinite update cycles.
+ * Call it when internal state updates with the updated value of the option.
+ */
 export default function useSyncOption<TOption>(
 	option: Ref<TOption | undefined> | undefined,
 	onOptionChange: (option: TOption) => void,

--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -48,8 +48,8 @@ export class DialogModel extends StateModel<
 	/**
 	 * Initialize a component of the model. This should run before the component
 	 * is mounted and before a reference to the DOM is obtained.
-	 * @param type The type of component being initialized
-	 * @returns The assigned ID for the component
+	 * @param type The type of component being initialized.
+	 * @returns The assigned ID for the component.
 	 */
 	init(type: DialogComponentType): string {
 		this.#components.set(type, {id: type, type, mounted: false});
@@ -70,7 +70,7 @@ export class DialogModel extends StateModel<
 	/**
 	 * Mark a component as mounted. This signals when a component has completed
 	 * its initialization phase and is ready to receive events.
-	 * @param componentId The ID of the component to mount
+	 * @param componentId The ID of the component to mount.
 	 */
 	mount(componentId: string) {
 		const component = this.#components.get(componentId);
@@ -96,8 +96,8 @@ export class DialogModel extends StateModel<
 
 	/**
 	 * Save a reference to the DOM node that the component abstracts over.
-	 * @param componentId The ID of the component that holds the node reference
-	 * @param node The DOM node reference
+	 * @param componentId The ID of the component that holds the node reference.
+	 * @param node The DOM node reference.
 	 */
 	bindNode(componentId: string, node: HTMLElement) {
 		const component = this.#components.get(componentId);
@@ -146,9 +146,9 @@ export class DialogModel extends StateModel<
 
 	/**
 	 * Get the required DOM attributes for a component with a given state.
-	 * @param componentId The component to get attributes for
+	 * @param componentId The component to get attributes for.
 	 * @param state If the component attributes are static, this can be omitted.
-	 * @returns An object describing the DOM attributes to apply to the component node
+	 * @returns An object describing the DOM attributes to apply to the component node.
 	 */
 	componentAttributes(componentId: string, state?: DialogModelState) {
 		const resolvedState = state ?? this.getState();

--- a/packages/dialog/react/lib/DialogClose.tsx
+++ b/packages/dialog/react/lib/DialogClose.tsx
@@ -48,7 +48,7 @@ const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
 		>(
 			(ev) => {
 				onClick?.(ev);
-				resolvedModel.setState((prevState) => ({...prevState, open: false}));
+				resolvedModel.close();
 			},
 			[resolvedModel],
 		);

--- a/packages/dialog/react/lib/DialogTrigger.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.tsx
@@ -50,7 +50,7 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 		>(
 			(ev) => {
 				onClick?.(ev);
-				resolvedModel.setState((prevState) => ({...prevState, open: true}));
+				resolvedModel.open();
 			},
 			[resolvedModel],
 		);

--- a/packages/dialog/react/lib/useDialog.tsx
+++ b/packages/dialog/react/lib/useDialog.tsx
@@ -1,4 +1,3 @@
-import type {DevOptions} from '@ally-ui/core';
 import {
 	DialogModel,
 	DialogModelOptions,
@@ -14,16 +13,22 @@ export interface UseDialogOptions extends DialogModelOptions {
 
 export type UseDialogValue = [DialogModel, DialogModelState];
 
-export default function useDialog(
-	{initialOpen, onOpenChange, open}: UseDialogOptions = {},
-	devOptions: DevOptions = {},
-): UseDialogValue {
+export default function useDialog({
+	initialOpen,
+	onOpenChange,
+	open,
+}: UseDialogOptions = {}): UseDialogValue {
 	const id = React.useId();
-	const model = useRunOnce(
-		() => new DialogModel(id, {initialOpen}, devOptions),
-	);
+	const model = useRunOnce(() => new DialogModel(id, {initialOpen}));
 
 	const [state, setState] = React.useState(() => model.initialState);
+
+	useRunOnce(() =>
+		model.setOptions((prevOptions) => ({
+			...prevOptions,
+			requestStateUpdate: setState,
+		})),
+	);
 
 	useSyncOption({
 		option: open,
@@ -34,11 +39,12 @@ export default function useDialog(
 		onInternalChange: onOpenChange,
 	});
 
-	model.setOptions((prevOptions) => ({
-		...prevOptions,
-		state,
-		onStateChange: setState,
-	}));
+	React.useEffect(
+		function updateState() {
+			model.setState(state);
+		},
+		[state],
+	);
 
 	const flushDOM = useLayoutPromise([state]);
 	model.setUIOptions({

--- a/packages/dialog/react/lib/useDialog.tsx
+++ b/packages/dialog/react/lib/useDialog.tsx
@@ -40,7 +40,7 @@ export default function useDialog({
 	});
 
 	React.useEffect(
-		function updateState() {
+		function onStateUpdate() {
 			model.setState(state);
 		},
 		[state],

--- a/packages/dialog/svelte/lib/DialogClose.svelte
+++ b/packages/dialog/svelte/lib/DialogClose.svelte
@@ -44,8 +44,7 @@
 	{...$resolvedModel.componentAttributes(id)}
 	{...$$restProps}
 	use:eventForwarder
-	on:click={() =>
-		$resolvedModel.setState((prevState) => ({...prevState, open: false}))}
+	on:click={() => $resolvedModel.close()}
 >
 	<slot />
 </button>

--- a/packages/dialog/svelte/lib/DialogTrigger.svelte
+++ b/packages/dialog/svelte/lib/DialogTrigger.svelte
@@ -44,8 +44,7 @@
 	{...$resolvedModel.componentAttributes(id)}
 	{...$$restProps}
 	use:eventForwarder
-	on:click={() =>
-		$resolvedModel.setState((prevState) => ({...prevState, open: true}))}
+	on:click={() => $resolvedModel.open()}
 >
 	<slot />
 </button>

--- a/packages/dialog/svelte/lib/createDialog.ts
+++ b/packages/dialog/svelte/lib/createDialog.ts
@@ -1,10 +1,10 @@
 import {DialogModel, type DialogModelOptions} from '@ally-ui/core-dialog';
-import {useSyncOption, type ReadOrWritable} from '@ally-ui/svelte';
+import {useSyncOption} from '@ally-ui/svelte';
 import {tick} from 'svelte';
-import {readable, writable, type Readable} from 'svelte/store';
+import {readable, writable, type Readable, type Writable} from 'svelte/store';
 
 export interface CreateDialogOptions extends DialogModelOptions {
-	openStore?: ReadOrWritable<boolean>;
+	openStore?: Writable<boolean>;
 }
 
 export default function createDialog({
@@ -28,18 +28,21 @@ export default function createDialog({
 		},
 	}));
 
-	const [updateOpen, watchOpen] = useSyncOption(openStore, ($open) => {
-		state.update((prevState) => ({...prevState, open: $open}));
-	});
+	const [updateOpenOption, watchOpenOption] = useSyncOption(
+		openStore,
+		($open) => {
+			state.update((prevState) => ({...prevState, open: $open}));
+		},
+	);
 
 	const modelStore = readable(model, (set) => {
 		const unsubscribeState = state.subscribe(($state) => {
 			model.setState($state);
-			updateOpen($state.open);
+			updateOpenOption($state.open);
 			set(model);
 		});
 
-		const unsubscribeOpen = watchOpen();
+		const unsubscribeOpen = watchOpenOption();
 
 		return () => {
 			unsubscribeState();

--- a/packages/dialog/vue/lib/DialogClose.vue
+++ b/packages/dialog/vue/lib/DialogClose.vue
@@ -45,9 +45,7 @@ watchEffect(() => {
 			...resolvedModel.componentAttributes(id),
 			...$attrs,
 		}"
-		@click="
-			() => resolvedModel.setState((prevState) => ({...prevState, open: false}))
-		"
+		@click="() => resolvedModel.close()"
 	>
 		<slot />
 	</button>

--- a/packages/dialog/vue/lib/DialogTrigger.vue
+++ b/packages/dialog/vue/lib/DialogTrigger.vue
@@ -47,9 +47,7 @@ watchEffect(() => {
 			...resolvedModel.componentAttributes(id, state),
 			...$attrs,
 		}"
-		@click="
-			() => resolvedModel.setState((prevState) => ({...prevState, open: true}))
-		"
+		@click="() => resolvedModel.open()"
 	>
 		<slot />
 	</button>

--- a/packages/dialog/vue/lib/useDialog.ts
+++ b/packages/dialog/vue/lib/useDialog.ts
@@ -33,13 +33,13 @@ export default function useDialog({
 		},
 	}));
 
-	const updateOpen = useSyncOption<boolean>(openRef, (open) => {
+	const updateOpenOption = useSyncOption<boolean>(openRef, (open) => {
 		state.value = {...state.value, open};
 	});
 
-	watchEffect(function onInternalChange() {
+	watchEffect(function onStateUpdate() {
 		model.setState(state.value);
-		updateOpen(state.value.open);
+		updateOpenOption(state.value.open);
 	});
 
 	model.setUIOptions({

--- a/packages/dialog/vue/lib/useDialog.ts
+++ b/packages/dialog/vue/lib/useDialog.ts
@@ -1,4 +1,3 @@
-import type {DevOptions} from '@ally-ui/core';
 import {
 	DialogModel,
 	type DialogModelOptions,
@@ -13,34 +12,33 @@ export interface UseDialogOptions extends DialogModelOptions {
 
 export type UseDialogValue = [DialogModel, Ref<DialogModelState>];
 
-export default function useDialog(
-	{openRef, initialOpen}: UseDialogOptions = {},
-	devOptions: DevOptions = {},
-): UseDialogValue {
+export default function useDialog({
+	openRef,
+	initialOpen,
+}: UseDialogOptions = {}): UseDialogValue {
 	// TODO Generate SSR-safe IDs.
 	const id = '0';
-	const model = new DialogModel(id, {initialOpen}, devOptions);
+	const model = new DialogModel(id, {initialOpen});
 
 	const state = ref(model.initialState);
+
+	model.setOptions((prevOptions) => ({
+		...prevOptions,
+		requestStateUpdate: (updater) => {
+			if (updater instanceof Function) {
+				state.value = updater(state.value);
+			} else {
+				state.value = updater;
+			}
+		},
+	}));
 
 	const updateOpen = useSyncOption<boolean>(openRef, (open) => {
 		state.value = {...state.value, open};
 	});
 
 	watchEffect(function onInternalChange() {
-		model.setOptions((prevOptions) => {
-			return {
-				...prevOptions,
-				state: state.value,
-				onStateChange: (updater) => {
-					if (updater instanceof Function) {
-						state.value = updater(state.value);
-					} else {
-						state.value = updater;
-					}
-				},
-			};
-		});
+		model.setState(state.value);
 		updateOpen(state.value.open);
 	});
 


### PR DESCRIPTION
This commit drastically simplifies how state management works with Ally UI.

State no longer exists as a property of the resolved options. Instead, state is a private object property that exists on the model itself.

This allows state to be a proxied object for UI libraries that use proxies for their reactive systems.

## Updated state initialization flow

For this example, we will use Vue's `ref`. However, the same initialization flow applies to all state systems.

1. Create a new instance of the model

```ts
const model = new DialogModel(id, options);
```

2. Create a new managed state instance to be used with the UI library with `model.initialState` as the initial state value.

```ts
const state = ref(model.initialState);
```

3. Configure the model's options to update state when the model requests.

```ts
model.setOptions((prevOptions) => ({
  ...prevOptions,
  requestStateUpdate: (updater) => {
    if (updater instanceof Function) {
      state.value = updater(state.value);
    } else {
      state.value = updater;
    }
  },
});
```

4. Synchronize any external options using the common helpers e.g. `import {useSyncOption} from @ally-ui/vue`.

5. Watch for changes to state and update the model's internal state.

```ts
watchEffect(function updateModelState() {
  model.setState(state.value);
});
```

6. Set UI library specific DOM options.

```ts
model.setUIOptions({
  flushDOM: nextTick,
});
```