### PR TITLE
Remove default exports

### DIFF
--- a/packages/common/dev/lib/main.ts
+++ b/packages/common/dev/lib/main.ts
@@ -1,1 +1,1 @@
-export {default as matchers} from './matchers';
+export {matchers} from './matchers';

--- a/packages/common/dev/lib/matchers/index.ts
+++ b/packages/common/dev/lib/matchers/index.ts
@@ -1,5 +1,5 @@
 import {toHaveFocusWithin} from './toHaveFocusWithin';
 
-export default {
+export const matchers = {
 	toHaveFocusWithin,
 };

--- a/packages/common/react/lib/main.ts
+++ b/packages/common/react/lib/main.ts
@@ -1,4 +1,4 @@
-export {default as useLayoutPromise} from './useLayoutPromise';
-export {default as useMultipleRefs} from './useMultipleRefs';
-export {default as useRunOnce} from './useRunOnce';
-export {default as useSyncedOption} from './useSyncedOption';
+export {useLayoutPromise} from './useLayoutPromise';
+export {useMultipleRefs} from './useMultipleRefs';
+export {useRunOnce} from './useRunOnce';
+export {useSyncedOption} from './useSyncedOption';

--- a/packages/common/react/lib/useLayoutPromise.tsx
+++ b/packages/common/react/lib/useLayoutPromise.tsx
@@ -5,7 +5,7 @@ import React from 'react';
  * @param deps The state to wait on update for.
  * @returns A getter of a Promise that resolves when the layout effects of `deps` is committed.
  */
-export default function useLayoutPromise(
+export function useLayoutPromise(
 	deps: React.DependencyList,
 ): () => Promise<void> {
 	const savedWaitForDOMResolves = React.useRef<Function[]>([]);

--- a/packages/common/react/lib/useMultipleRefs.tsx
+++ b/packages/common/react/lib/useMultipleRefs.tsx
@@ -24,8 +24,6 @@ function combinedRef<TInstance>(refs: React.Ref<TInstance>[]) {
  * @param refs The refs that should receive the instance.
  * @returns The combined ref.
  */
-export default function useMultipleRefs<TInstance>(
-	...refs: React.Ref<TInstance>[]
-) {
+export function useMultipleRefs<TInstance>(...refs: React.Ref<TInstance>[]) {
 	return React.useCallback(combinedRef(refs), refs);
 }

--- a/packages/common/react/lib/useRunOnce.tsx
+++ b/packages/common/react/lib/useRunOnce.tsx
@@ -5,7 +5,7 @@ import React from 'react';
  * @param runner The function to run.
  * @returns The value returned by `runner`.
  */
-export default function useRunOnce<TReturn>(runner: () => TReturn) {
+export function useRunOnce<TReturn>(runner: () => TReturn) {
 	const [value] = React.useState(runner);
 	return value;
 }

--- a/packages/common/react/lib/useSyncedOption.tsx
+++ b/packages/common/react/lib/useSyncedOption.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import useRunOnce from './useRunOnce';
+import {useRunOnce} from './useRunOnce';
 
 export interface UseSyncedOptionOptions<TOption> {
 	/**
@@ -27,7 +27,7 @@ export interface UseSyncedOptionOptions<TOption> {
 /**
  * Synchronize state between an external option and internal state.
  */
-export default function useSyncedOption<TOption>({
+export function useSyncedOption<TOption>({
 	option,
 	internal,
 	onOptionChange,

--- a/packages/common/svelte/lib/createEventForwarder.ts
+++ b/packages/common/svelte/lib/createEventForwarder.ts
@@ -23,7 +23,7 @@ interface CreateEventForwarderOptions {
 }
 
 // CREDIT https://github.com/rgossiaux/svelte-headlessui/blob/master/src/lib/internal/forwardEventsBuilder.ts
-export default function createEventForwarder(
+export function createEventForwarder(
 	component: SvelteComponent,
 	{except = []}: CreateEventForwarderOptions = {},
 ) {

--- a/packages/common/svelte/lib/createSyncedOption.ts
+++ b/packages/common/svelte/lib/createSyncedOption.ts
@@ -17,7 +17,7 @@ import {isWritable, type ReadOrWritable} from './store';
  * The second function starts a subscriber on the option store to update
  * internal state when it updates. It returns an unsubscriber for cleanup.
  */
-export default function createSyncedOption<TOption>(
+export function createSyncedOption<TOption>(
 	option: ReadOrWritable<TOption> | undefined,
 	onOptionChange: (option: TOption) => void,
 ) {

--- a/packages/common/svelte/lib/main.ts
+++ b/packages/common/svelte/lib/main.ts
@@ -1,3 +1,3 @@
-export {default as createEventForwarder} from './createEventForwarder';
-export {default as createSyncedOption} from './createSyncedOption';
+export {createEventForwarder} from './createEventForwarder';
+export {createSyncedOption} from './createSyncedOption';
 export * from './store';

--- a/packages/common/vue/lib/main.ts
+++ b/packages/common/vue/lib/main.ts
@@ -1,1 +1,1 @@
-export {default as useSyncedOption} from './useSyncedOption';
+export {useSyncedOption} from './useSyncedOption';

--- a/packages/common/vue/lib/useSyncedOption.ts
+++ b/packages/common/vue/lib/useSyncedOption.ts
@@ -10,7 +10,7 @@ import {watchEffect, type Ref} from 'vue';
  * @returns A function to update the external option and mitigate infinite update cycles.
  * Call it when internal state updates with the updated value of the option.
  */
-export default function useSyncedOption<TOption>(
+export function useSyncedOption<TOption>(
 	option: Ref<TOption | undefined> | undefined,
 	onOptionChange: (option: TOption) => void,
 ) {

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -1,5 +1,5 @@
 import {DialogModelContext, DialogStateContext} from './context';
-import useDialog, {UseDialogOptions} from './useDialog';
+import {useDialog, type UseDialogOptions} from './useDialog';
 
 export interface DialogRootProps
 	extends React.PropsWithChildren,

--- a/packages/dialog/react/lib/main.ts
+++ b/packages/dialog/react/lib/main.ts
@@ -14,4 +14,4 @@ export const Dialog = {
 	Trigger,
 };
 
-export {default as useDialog} from './useDialog';
+export {useDialog} from './useDialog';

--- a/packages/dialog/react/lib/useDialog.tsx
+++ b/packages/dialog/react/lib/useDialog.tsx
@@ -13,7 +13,7 @@ export interface UseDialogOptions extends DialogModelOptions {
 
 export type UseDialogValue = [DialogModel, DialogModelState];
 
-export default function useDialog({
+export function useDialog({
 	initialOpen,
 	onOpenChange,
 	open,

--- a/packages/dialog/svelte/lib/DialogRoot.svelte
+++ b/packages/dialog/svelte/lib/DialogRoot.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {writable} from 'svelte/store';
 	import {setDialogContext} from './context';
-	import createDialog from './createDialog';
+	import {createDialog} from './main';
 
 	interface $$Props {
 		open?: boolean;

--- a/packages/dialog/svelte/lib/createDialog.ts
+++ b/packages/dialog/svelte/lib/createDialog.ts
@@ -6,7 +6,7 @@ export interface CreateDialogOptions extends DialogModelOptions {
 	openStore?: Writable<boolean>;
 }
 
-export default function createDialog({
+export function createDialog({
 	initialOpen,
 	openStore,
 }: CreateDialogOptions = {}): Readable<DialogModel> {

--- a/packages/dialog/svelte/lib/main.ts
+++ b/packages/dialog/svelte/lib/main.ts
@@ -14,4 +14,4 @@ export const Dialog = {
 	Trigger,
 };
 
-export {default as createDialog} from './createDialog';
+export {createDialog} from './createDialog';

--- a/packages/dialog/vue/lib/main.ts
+++ b/packages/dialog/vue/lib/main.ts
@@ -4,4 +4,4 @@ export {default as DialogDescription} from './DialogDescription.vue';
 export {default as DialogRoot} from './DialogRoot.vue';
 export {default as DialogTitle} from './DialogTitle.vue';
 export {default as DialogTrigger} from './DialogTrigger.vue';
-export {default as useDialog} from './useDialog';
+export {useDialog} from './useDialog';

--- a/packages/dialog/vue/lib/useDialog.ts
+++ b/packages/dialog/vue/lib/useDialog.ts
@@ -12,7 +12,7 @@ export interface UseDialogOptions extends DialogModelOptions {
 
 export type UseDialogValue = [DialogModel, Ref<DialogModelState>];
 
-export default function useDialog({
+export function useDialog({
 	openRef,
 	initialOpen,
 }: UseDialogOptions = {}): UseDialogValue {


### PR DESCRIPTION
WIth the exception of component exports, it feels like there's no reason to use default exports.