### PR TITLE
More specific warning

### DIFF
--- a/packages/dialog/core/lib/main.ts
+++ b/packages/dialog/core/lib/main.ts
@@ -109,19 +109,20 @@ export class DialogModel extends StateModel<
 		}
 		component.node = node;
 		if (component.type === 'content') {
-			this.#checkTitle();
+			this.#checkTitleInContent();
 			if (this.#waitingToOpen) {
 				this.#onOpenChangeEffect(true);
 			}
 		}
 	}
 
-	#checkTitle() {
+	static MISSING_TITLE_WARNING = `<Dialog.Content/> should contain a visible <Dialog.Title/> component.
+This provides the user with a recognizable name for the dialog by enforcing an element with \`aria-labelledby\` exists in the dialog.`;
+
+	#checkTitleInContent() {
 		const title = findLastInMap(this.#components, (c) => c.type === 'title');
 		if (title === undefined) {
-			console.warn(
-				'Dialogs should contain a title component for accessibility reasons',
-			);
+			console.warn(DialogModel.MISSING_TITLE_WARNING);
 		}
 	}
 

--- a/packages/dialog/react/lib/__tests__/warnings/missing-title.test.tsx
+++ b/packages/dialog/react/lib/__tests__/warnings/missing-title.test.tsx
@@ -1,3 +1,4 @@
+import {DialogModel} from '@ally-ui/core-dialog';
 import {cleanup, render, screen} from '@testing-library/react';
 import React from 'react';
 import Dialog from '../../main';
@@ -26,7 +27,5 @@ it('warns the user if the title component is missing', async () => {
 	const warnSpy = vi.spyOn(console, 'warn');
 	render(<MissingTitle />);
 	await screen.findByTestId('content');
-	expect(warnSpy).toHaveBeenCalledWith(
-		'Dialogs should contain a title component for accessibility reasons',
-	);
+	expect(warnSpy).toHaveBeenCalledWith(DialogModel.MISSING_TITLE_WARNING);
 });

--- a/packages/dialog/svelte/lib/__tests__/warnings/missing-title.test.ts
+++ b/packages/dialog/svelte/lib/__tests__/warnings/missing-title.test.ts
@@ -1,3 +1,4 @@
+import {DialogModel} from '@ally-ui/core-dialog';
 import {cleanup, render, screen} from '@testing-library/svelte';
 import MissingTitle from './missing-title.test.svelte';
 
@@ -9,7 +10,5 @@ it('warns the user if the title component is missing', async () => {
 	const warnSpy = vi.spyOn(console, 'warn');
 	render(MissingTitle);
 	await screen.findByTestId('content');
-	expect(warnSpy).toHaveBeenCalledWith(
-		'Dialogs should contain a title component for accessibility reasons',
-	);
+	expect(warnSpy).toHaveBeenCalledWith(DialogModel.MISSING_TITLE_WARNING);
 });

--- a/packages/dialog/vue/lib/__tests__/warnings/missing-title.test.ts
+++ b/packages/dialog/vue/lib/__tests__/warnings/missing-title.test.ts
@@ -1,3 +1,4 @@
+import {DialogModel} from '@ally-ui/core-dialog';
 import {cleanup, render, screen} from '@testing-library/vue';
 import MissingTitle from './missing-title.test.vue';
 
@@ -9,7 +10,5 @@ it('warns the user if the title component is missing', async () => {
 	const warnSpy = vi.spyOn(console, 'warn');
 	render(MissingTitle);
 	await screen.findByTestId('content');
-	expect(warnSpy).toHaveBeenCalledWith(
-		'Dialogs should contain a title component for accessibility reasons',
-	);
+	expect(warnSpy).toHaveBeenCalledWith(DialogModel.MISSING_TITLE_WARNING);
 });


### PR DESCRIPTION
Improve the warning emitted when the title component is missing from the dialog content.