### PR TITLE
Fix Svelte exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 			"devDependencies": {
 				"@nrwl/nx-cloud": "latest",
 				"@rollup/plugin-typescript": "^8.3.4",
+				"@sveltejs/package": "^1.0.0-next.3",
 				"@sveltejs/vite-plugin-svelte": "^1.0.1",
 				"@testing-library/dom": "^8.16.1",
 				"@testing-library/jest-dom": "^5.16.5",
@@ -2946,6 +2947,27 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
 			"integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
 			"dev": true
+		},
+		"node_modules/@sveltejs/package": {
+			"version": "1.0.0-next.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-1.0.0-next.3.tgz",
+			"integrity": "sha512-wlvxTScX0+c3KeUfgcELckLEu92Lz672Hh9zu3v4SDnByVwU6UNWhuLjff2osSVit/MLRIxe2XudnqZlmQj3OQ==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.3",
+				"kleur": "^4.1.4",
+				"sade": "^1.8.1",
+				"svelte2tsx": "~0.5.10"
+			},
+			"bin": {
+				"svelte-package": "svelte-package.js"
+			},
+			"engines": {
+				"node": ">=16.14"
+			},
+			"peerDependencies": {
+				"svelte": "^3.44.0"
+			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
 			"version": "1.0.1",
@@ -15297,6 +15319,18 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.28.tgz",
 			"integrity": "sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==",
 			"dev": true
+		},
+		"@sveltejs/package": {
+			"version": "1.0.0-next.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-1.0.0-next.3.tgz",
+			"integrity": "sha512-wlvxTScX0+c3KeUfgcELckLEu92Lz672Hh9zu3v4SDnByVwU6UNWhuLjff2osSVit/MLRIxe2XudnqZlmQj3OQ==",
+			"dev": true,
+			"requires": {
+				"chokidar": "^3.5.3",
+				"kleur": "^4.1.4",
+				"sade": "^1.8.1",
+				"svelte2tsx": "~0.5.10"
+			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"devDependencies": {
 		"@nrwl/nx-cloud": "latest",
 		"@rollup/plugin-typescript": "^8.3.4",
+		"@sveltejs/package": "^1.0.0-next.3",
 		"@sveltejs/vite-plugin-svelte": "^1.0.1",
 		"@testing-library/dom": "^8.16.1",
 		"@testing-library/jest-dom": "^5.16.5",

--- a/packages/common/svelte/package.json
+++ b/packages/common/svelte/package.json
@@ -3,8 +3,8 @@
 	"version": "0.0.11",
 	"scripts": {
 		"example": "vite",
-		"build": "tsc && vite build",
-		"build:watch": "vite build --watch",
+		"build": "svelte-package && rimraf dist/package.json",
+		"build:watch": "svelte-package --watch",
 		"clean": "rimraf dist"
 	},
 	"author": "Bryan Lee",
@@ -22,13 +22,12 @@
 	"files": [
 		"dist"
 	],
-	"main": "./dist/main.umd.cjs",
 	"module": "./dist/main.js",
 	"types": "./dist/main.d.ts",
+	"svelte": "./dist/main.js",
 	"exports": {
 		".": {
-			"import": "./dist/main.js",
-			"require": "./dist/main.umd.cjs"
+			"import": "./dist/main.js"
 		}
 	},
 	"sideEffects": false,

--- a/packages/common/svelte/svelte.config.js
+++ b/packages/common/svelte/svelte.config.js
@@ -4,4 +4,10 @@ export default {
 	// Consult https://github.com/sveltejs/svelte-preprocess
 	// for more information about preprocessors
 	preprocess: sveltePreprocess(),
+	package: {
+		source: 'lib',
+		dir: 'dist',
+		exports: (filepath) => filepath === 'main.ts',
+		files: (filepath) => !/^__tests__\/.+/.test(filepath),
+	},
 };

--- a/packages/common/svelte/vite.config.ts
+++ b/packages/common/svelte/vite.config.ts
@@ -1,24 +1,7 @@
-import typescript from '@rollup/plugin-typescript';
 import {svelte} from '@sveltejs/vite-plugin-svelte';
-import {resolve} from 'path';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	build: {
-		lib: {
-			entry: resolve(__dirname, 'lib/main.ts'),
-			name: '@ally-ui/svelte',
-			fileName: 'main',
-		},
-		rollupOptions: {
-			external: ['svelte'],
-			plugins: [
-				typescript({
-					tsconfig: './tsconfig.build.json',
-				}),
-			],
-		},
-	},
 	plugins: [svelte()],
 });

--- a/packages/dialog/svelte/lib/DialogClose.svelte
+++ b/packages/dialog/svelte/lib/DialogClose.svelte
@@ -1,9 +1,14 @@
+<script lang="ts" context="module">
+	export type DialogCloseProps = svelteHTML.IntrinsicElements['button'] & {
+		node?: HTMLButtonElement | undefined | null;
+	};
+</script>
+
 <script lang="ts">
 	import {DialogCloseModel} from '@ally-ui/core-dialog';
 	import {createEventForwarder} from '@ally-ui/svelte';
 	import {get_current_component, onMount} from 'svelte/internal';
 	import {getDialogRootModel} from './context';
-	import type {DialogCloseProps} from './DialogClose';
 
 	type $$Props = DialogCloseProps;
 

--- a/packages/dialog/svelte/lib/DialogClose.ts
+++ b/packages/dialog/svelte/lib/DialogClose.ts
@@ -1,3 +1,0 @@
-export type DialogCloseProps = svelteHTML.IntrinsicElements['button'] & {
-	node?: HTMLButtonElement | undefined | null;
-};

--- a/packages/dialog/svelte/lib/DialogContent.svelte
+++ b/packages/dialog/svelte/lib/DialogContent.svelte
@@ -1,10 +1,15 @@
+<script lang="ts" context="module">
+	export type DialogContentProps = svelteHTML.IntrinsicElements['div'] & {
+		node?: HTMLDivElement | undefined | null;
+	};
+</script>
+
 <script lang="ts">
 	import {DialogContentModel} from '@ally-ui/core-dialog';
 	import {createEventForwarder} from '@ally-ui/svelte';
 	import {get_current_component, onMount} from 'svelte/internal';
 	import {readable} from 'svelte/store';
 	import {getDialogRootModel, getDialogRootState} from './context';
-	import type {DialogContentProps} from './DialogContent';
 
 	type $$Props = DialogContentProps;
 

--- a/packages/dialog/svelte/lib/DialogContent.ts
+++ b/packages/dialog/svelte/lib/DialogContent.ts
@@ -1,3 +1,0 @@
-export type DialogContentProps = svelteHTML.IntrinsicElements['div'] & {
-	node?: HTMLDivElement | undefined | null;
-};

--- a/packages/dialog/svelte/lib/DialogDescription.svelte
+++ b/packages/dialog/svelte/lib/DialogDescription.svelte
@@ -1,9 +1,14 @@
+<script lang="ts" context="module">
+	export type DialogDescriptionProps = svelteHTML.IntrinsicElements['p'] & {
+		node?: HTMLParagraphElement | undefined | null;
+	};
+</script>
+
 <script lang="ts">
 	import {DialogDescriptionModel} from '@ally-ui/core-dialog';
 	import {createEventForwarder} from '@ally-ui/svelte';
 	import {get_current_component, onMount} from 'svelte/internal';
 	import {getDialogRootModel} from './context';
-	import type {DialogDescriptionProps} from './DialogDescription';
 
 	type $$Props = DialogDescriptionProps;
 

--- a/packages/dialog/svelte/lib/DialogDescription.ts
+++ b/packages/dialog/svelte/lib/DialogDescription.ts
@@ -1,3 +1,0 @@
-export type DialogDescriptionProps = svelteHTML.IntrinsicElements['p'] & {
-	node?: HTMLParagraphElement | undefined | null;
-};

--- a/packages/dialog/svelte/lib/DialogRoot.svelte
+++ b/packages/dialog/svelte/lib/DialogRoot.svelte
@@ -1,9 +1,15 @@
+<script lang="ts" context="module">
+	export interface DialogRootProps {
+		open?: boolean;
+		initialOpen?: boolean;
+	}
+</script>
+
 <script lang="ts">
 	import {DialogRootModel} from '@ally-ui/core-dialog';
 	import {bindStore, createSyncedOption} from '@ally-ui/svelte';
 	import {derived, writable} from 'svelte/store';
 	import {setDialogRootModel, setDialogRootState} from './context';
-	import type {DialogRootProps} from './DialogRoot';
 
 	type $$Props = DialogRootProps;
 

--- a/packages/dialog/svelte/lib/DialogRoot.ts
+++ b/packages/dialog/svelte/lib/DialogRoot.ts
@@ -1,4 +1,0 @@
-export interface DialogRootProps {
-	open?: boolean;
-	initialOpen?: boolean;
-}

--- a/packages/dialog/svelte/lib/DialogTitle.svelte
+++ b/packages/dialog/svelte/lib/DialogTitle.svelte
@@ -1,9 +1,14 @@
+<script lang="ts" context="module">
+	export type DialogTitleProps = svelteHTML.IntrinsicElements['h1'] & {
+		node?: HTMLHeadingElement | undefined | null;
+	};
+</script>
+
 <script lang="ts">
 	import {DialogTitleModel} from '@ally-ui/core-dialog';
 	import {createEventForwarder} from '@ally-ui/svelte';
 	import {get_current_component, onMount} from 'svelte/internal';
 	import {getDialogRootModel} from './context';
-	import type {DialogTitleProps} from './DialogTitle';
 
 	type $$Props = DialogTitleProps;
 

--- a/packages/dialog/svelte/lib/DialogTitle.ts
+++ b/packages/dialog/svelte/lib/DialogTitle.ts
@@ -1,3 +1,0 @@
-export type DialogTitleProps = svelteHTML.IntrinsicElements['h1'] & {
-	node?: HTMLHeadingElement | undefined | null;
-};

--- a/packages/dialog/svelte/lib/DialogTrigger.svelte
+++ b/packages/dialog/svelte/lib/DialogTrigger.svelte
@@ -1,10 +1,15 @@
+<script lang="ts" context="module">
+	export type DialogTriggerProps = svelteHTML.IntrinsicElements['button'] & {
+		node?: HTMLButtonElement | undefined | null;
+	};
+</script>
+
 <script lang="ts">
 	import {DialogTriggerModel} from '@ally-ui/core-dialog';
 	import {createEventForwarder} from '@ally-ui/svelte';
 	import {get_current_component, onMount} from 'svelte/internal';
 	import {readable} from 'svelte/store';
 	import {getDialogRootModel, getDialogRootState} from './context';
-	import type {DialogTriggerProps} from './DialogTrigger';
 
 	type $$Props = DialogTriggerProps;
 

--- a/packages/dialog/svelte/lib/DialogTrigger.ts
+++ b/packages/dialog/svelte/lib/DialogTrigger.ts
@@ -1,3 +1,0 @@
-export type DialogTriggerProps = svelteHTML.IntrinsicElements['button'] & {
-	node?: HTMLButtonElement | undefined | null;
-};

--- a/packages/dialog/svelte/lib/main.ts
+++ b/packages/dialog/svelte/lib/main.ts
@@ -1,15 +1,9 @@
 export * from '@ally-ui/core-dialog';
-export * from './DialogClose';
 export {default as DialogClose} from './DialogClose.svelte';
-export * from './DialogContent';
 export {default as DialogContent} from './DialogContent.svelte';
-export * from './DialogDescription';
 export {default as DialogDescription} from './DialogDescription.svelte';
-export * from './DialogRoot';
 export {default as DialogRoot} from './DialogRoot.svelte';
-export * from './DialogTitle';
 export {default as DialogTitle} from './DialogTitle.svelte';
-export * from './DialogTrigger';
 export {default as DialogTrigger} from './DialogTrigger.svelte';
 
 import Close from './DialogClose.svelte';

--- a/packages/dialog/svelte/package.json
+++ b/packages/dialog/svelte/package.json
@@ -3,8 +3,8 @@
 	"version": "0.0.11",
 	"scripts": {
 		"example": "vite",
-		"build": "tsc && vite build",
-		"build:watch": "vite build --watch",
+		"build": "svelte-package && rimraf dist/package.json",
+		"build:watch": "svelte-package --watch",
 		"clean": "rimraf dist",
 		"test": "vitest run",
 		"test:watch": "vitest",
@@ -25,13 +25,12 @@
 	"files": [
 		"dist"
 	],
-	"main": "./dist/main.umd.cjs",
 	"module": "./dist/main.js",
 	"types": "./dist/main.d.ts",
+	"svelte": "./dist/main.js",
 	"exports": {
 		".": {
-			"import": "./dist/main.js",
-			"require": "./dist/main.umd.cjs"
+			"import": "./dist/main.js"
 		}
 	},
 	"sideEffects": false,

--- a/packages/dialog/svelte/svelte.config.js
+++ b/packages/dialog/svelte/svelte.config.js
@@ -4,4 +4,10 @@ export default {
 	// Consult https://github.com/sveltejs/svelte-preprocess
 	// for more information about preprocessors
 	preprocess: sveltePreprocess(),
+	package: {
+		source: 'lib',
+		dir: 'dist',
+		exports: (filepath) => filepath === 'main.ts',
+		files: (filepath) => !/^__tests__\/.+/.test(filepath),
+	},
 };

--- a/packages/dialog/svelte/vite.config.ts
+++ b/packages/dialog/svelte/vite.config.ts
@@ -1,24 +1,7 @@
-import typescript from '@rollup/plugin-typescript';
 import {svelte} from '@sveltejs/vite-plugin-svelte';
-import {resolve} from 'path';
 import {defineConfig} from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	build: {
-		lib: {
-			entry: resolve(__dirname, 'lib/main.ts'),
-			name: '@ally-ui/svelte-dialog',
-			fileName: 'main',
-		},
-		rollupOptions: {
-			external: ['svelte', /@ally-ui\/[\w-]+/],
-			plugins: [
-				typescript({
-					tsconfig: './tsconfig.build.json',
-				}),
-			],
-		},
-	},
 	plugins: [svelte()],
 });


### PR DESCRIPTION
Replace Rollup with `@sveltejs/package`.

Rollup was bundling all components with Svelte, causing runtime issues when used in applications.

`@sveltejs/package` allows us to export the components as is without compilation.