### PR TITLE
Export `package.json`

### DIFF
--- a/packages/common/core/package.json
+++ b/packages/common/core/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/common/focus-trap/package.json
+++ b/packages/common/focus-trap/package.json
@@ -32,7 +32,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/common/react/package.json
+++ b/packages/common/react/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"peerDependencies": {

--- a/packages/common/solid/package.json
+++ b/packages/common/solid/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"peerDependencies": {

--- a/packages/common/svelte/package.json
+++ b/packages/common/svelte/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/main.js"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"peerDependencies": {

--- a/packages/common/vue/package.json
+++ b/packages/common/vue/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"peerDependencies": {

--- a/packages/dialog/core/package.json
+++ b/packages/dialog/core/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/dialog/react/package.json
+++ b/packages/dialog/react/package.json
@@ -32,7 +32,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/dialog/solid/package.json
+++ b/packages/dialog/solid/package.json
@@ -29,7 +29,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/dialog/svelte/package.json
+++ b/packages/dialog/svelte/package.json
@@ -31,7 +31,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/main.js"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {

--- a/packages/dialog/vue/package.json
+++ b/packages/dialog/vue/package.json
@@ -32,7 +32,8 @@
 		".": {
 			"import": "./dist/main.js",
 			"require": "./dist/main.umd.cjs"
-		}
+		},
+		"./package.json": "./package.json"
 	},
 	"sideEffects": false,
 	"dependencies": {


### PR DESCRIPTION
Several build tools use `package.json` to optimize the bundle.

Since we are using an explicit `exports` field in our `package.json`, we also need to explicitly export `package.json`.