### PR TITLE
Test open initially set to `true`

### DIFF
--- a/packages/dialog/react/tests/focus/init-open-traps.test.tsx
+++ b/packages/dialog/react/tests/focus/init-open-traps.test.tsx
@@ -10,3 +10,9 @@ it('traps focus in the dialog if initially open', async () => {
 	const content = await screen.findByTestId('content');
 	expect(content).toHaveFocusWithin();
 });
+
+it('traps focus in the dialog if state is initially open', async () => {
+	render(<Focus open />);
+	const content = await screen.findByTestId('content');
+	expect(content).toHaveFocusWithin();
+});

--- a/packages/dialog/solid/tests/focus/init-open-traps.test.tsx
+++ b/packages/dialog/solid/tests/focus/init-open-traps.test.tsx
@@ -11,3 +11,11 @@ it('traps focus in the dialog if initially open', async () => {
 	await new Promise((res) => setTimeout(res));
 	expect(content).toHaveFocusWithin();
 });
+
+it('traps focus in the dialog if state is initially open', async () => {
+	render(() => <Focus open />);
+	const content = await screen.findByTestId('content');
+	// Solid needs another frame for the child components to be mounted.
+	await new Promise((res) => setTimeout(res));
+	expect(content).toHaveFocusWithin();
+});

--- a/packages/dialog/svelte/tests/focus/focus.test.svelte
+++ b/packages/dialog/svelte/tests/focus/focus.test.svelte
@@ -2,9 +2,10 @@
 	import Dialog from '../../lib/main';
 
 	export let initialOpen: boolean | undefined = undefined;
+	export let open: boolean | undefined = undefined;
 </script>
 
-<Dialog.Root {initialOpen}>
+<Dialog.Root {initialOpen} {open}>
 	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
 	<Dialog.Content data-testid="content">
 		<Dialog.Title data-testid="title">title</Dialog.Title>

--- a/packages/dialog/svelte/tests/focus/init-open-traps.test.ts
+++ b/packages/dialog/svelte/tests/focus/init-open-traps.test.ts
@@ -10,3 +10,9 @@ it('traps focus in the dialog if initially open', async () => {
 	const content = await screen.findByTestId('content');
 	expect(content).toHaveFocusWithin();
 });
+
+it('traps focus in the dialog if state is initially open', async () => {
+	render(Focus, {open: true});
+	const content = await screen.findByTestId('content');
+	expect(content).toHaveFocusWithin();
+});

--- a/packages/dialog/vue/tests/focus/init-open-traps.test.ts
+++ b/packages/dialog/vue/tests/focus/init-open-traps.test.ts
@@ -11,3 +11,10 @@ it('traps focus in the dialog if initially open', async () => {
 	await screen.findByTestId('content');
 	expect(await screen.findByTestId('content')).toHaveFocusWithin();
 });
+
+it('traps focus in the dialog if state is initially open', async () => {
+	render(Focus, {props: {open: true}});
+	// Vue needs another frame for the child components to be mounted.
+	await screen.findByTestId('content');
+	expect(await screen.findByTestId('content')).toHaveFocusWithin();
+});


### PR DESCRIPTION
`initialOpen` is set during initialization, while the `open` state variable is dynamically updated slightly after initialization.

We cannot fully synchronize the two options in the beginning, and we want to provide `initialOpen` as a simple option when the user does not need to manually control state.

This test makes sure that focus behaviour still works if state is initially set via `initialOpen` or `open`.