### PR TITLE
Remove references to options from state model

### DIFF
--- a/packages/common/core/lib/ComponentModel.ts
+++ b/packages/common/core/lib/ComponentModel.ts
@@ -6,15 +6,19 @@ export abstract class ComponentModel<
 	TOptions = any,
 	TState = any,
 	TAttributes = any,
-> extends StateModel<TOptions, TState> {
+> extends StateModel<TState> {
 	rootModel: TRootModel;
 	options: TOptions;
 	type: $ComponentTypeOf<TRootModel>;
 	mounted = false;
 	node?: HTMLElement;
 
-	constructor(rootModel: TRootModel, initialOptions: TOptions) {
-		super(initialOptions);
+	constructor(
+		rootModel: TRootModel,
+		initialOptions: TOptions,
+		initialState: TState = {} as TState,
+	) {
+		super(initialState);
 		this.rootModel = rootModel;
 		this.options = initialOptions;
 		this.type = this.getType();

--- a/packages/common/core/lib/RootModel.ts
+++ b/packages/common/core/lib/RootModel.ts
@@ -8,12 +8,12 @@ export abstract class RootModel<
 	TComponentType extends string = any,
 	TOptions extends RootOptions = any,
 	TState = any,
-> extends StateModel<TOptions, TState> {
+> extends StateModel<TState> {
 	id: string;
 	options: TOptions;
 
-	constructor(id: string, initialOptions: TOptions) {
-		super(initialOptions);
+	constructor(id: string, initialOptions: TOptions, initialState: TState) {
+		super(initialState);
 		this.id = id;
 		this.options = initialOptions;
 	}

--- a/packages/common/core/lib/StateModel.ts
+++ b/packages/common/core/lib/StateModel.ts
@@ -20,8 +20,7 @@ export interface StateOptions<TState> {
  * The model is initialized with a set of initial options. These options can be
  * reactively updated by the state implementation with `setOptions`.
  */
-export abstract class StateModel<TOptions, TState> {
-	#options: TOptions;
+export abstract class StateModel<TState> {
 	initialState: TState;
 	#previousState: TState;
 	/**
@@ -31,15 +30,12 @@ export abstract class StateModel<TOptions, TState> {
 	#state: TState;
 	#stateOptions: StateOptions<TState>;
 
-	constructor(initialOptions: TOptions) {
-		this.#options = initialOptions;
-		this.initialState = this.deriveInitialState(initialOptions);
-		this.#previousState = this.initialState;
-		this.#state = this.initialState;
+	constructor(initialState: TState) {
+		this.initialState = initialState;
+		this.#previousState = initialState;
+		this.#state = initialState;
 		this.#stateOptions = {};
 	}
-
-	abstract deriveInitialState(initialOptions: TOptions): TState;
 
 	getStateOptions() {
 		return this.#stateOptions;
@@ -80,16 +76,4 @@ export abstract class StateModel<TOptions, TState> {
 	 * @param previousState The previous state.
 	 */
 	watchStateChange?(newState: TState, previousState: TState): void;
-
-	getOptions(): TOptions {
-		return this.#options;
-	}
-
-	setOptions(updater: Updater<TOptions>) {
-		if (updater instanceof Function) {
-			this.#options = updater(this.#options);
-		} else {
-			this.#options = updater;
-		}
-	}
 }

--- a/packages/common/focus-trap/lib/FocusTrapModel.ts
+++ b/packages/common/focus-trap/lib/FocusTrapModel.ts
@@ -126,16 +126,12 @@ export class FocusTrapModel extends RootModel<
 	FocusTrapState
 > {
 	constructor(id: string, initialOptions: FocusTrapOptions) {
-		super(id, initialOptions);
+		super(id, initialOptions, {
+			active: initialOptions.initialActive ?? false,
+		});
 		if (this.getState().active) {
 			this.activate();
 		}
-	}
-
-	deriveInitialState(initialOptions: FocusTrapOptions): FocusTrapState {
-		return {
-			active: initialOptions.initialActive ?? false,
-		};
 	}
 
 	watchStateChange(newState: FocusTrapState, oldState: FocusTrapState) {

--- a/packages/dialog/core/lib/DialogCloseModel.ts
+++ b/packages/dialog/core/lib/DialogCloseModel.ts
@@ -13,10 +13,6 @@ export class DialogCloseModel extends ComponentModel<
 	DialogCloseModelState,
 	DialogCloseModelAttributes
 > {
-	deriveInitialState(): DialogCloseModelState {
-		return {};
-	}
-
 	getType(): DialogComponentType {
 		return 'close';
 	}

--- a/packages/dialog/core/lib/DialogContentModel.ts
+++ b/packages/dialog/core/lib/DialogContentModel.ts
@@ -24,10 +24,6 @@ export class DialogContentModel extends ComponentModel<
 	DialogContentModelState,
 	DialogContentModelAttributes
 > {
-	deriveInitialState(): DialogContentModelState {
-		return {};
-	}
-
 	getType(): DialogComponentType {
 		return 'content';
 	}

--- a/packages/dialog/core/lib/DialogDescriptionModel.ts
+++ b/packages/dialog/core/lib/DialogDescriptionModel.ts
@@ -15,10 +15,6 @@ export class DialogDescriptionModel extends ComponentModel<
 	DialogDescriptionModelState,
 	DialogDescriptionModelAttributes
 > {
-	deriveInitialState(): DialogDescriptionModelState {
-		return {};
-	}
-
 	getType(): DialogComponentType {
 		return 'description';
 	}

--- a/packages/dialog/core/lib/DialogRootModel.ts
+++ b/packages/dialog/core/lib/DialogRootModel.ts
@@ -24,19 +24,13 @@ export class DialogRootModel extends RootModel<
 	DialogRootModelState
 > {
 	constructor(id: string, initialOptions: DialogRootModelOptions) {
-		super(id, initialOptions);
+		super(id, initialOptions, {
+			open: initialOptions.initialOpen ?? false,
+			modal: initialOptions.modal ?? true,
+		});
 		if (this.initialState.open) {
 			this.#onOpenChangeEffect(true);
 		}
-	}
-
-	deriveInitialState(
-		initialOptions: DialogRootModelOptions,
-	): DialogRootModelState {
-		return {
-			open: initialOptions.initialOpen ?? false,
-			modal: initialOptions.modal ?? true,
-		};
 	}
 
 	watchBind(component: ComponentModel) {

--- a/packages/dialog/core/lib/DialogTitleModel.ts
+++ b/packages/dialog/core/lib/DialogTitleModel.ts
@@ -15,10 +15,6 @@ export class DialogTitleModel extends ComponentModel<
 	DialogTitleModelState,
 	DialogTitleModelAttributes
 > {
-	deriveInitialState(): DialogTitleModelState {
-		return {};
-	}
-
 	getType(): DialogComponentType {
 		return 'title';
 	}

--- a/packages/dialog/core/lib/DialogTriggerModel.ts
+++ b/packages/dialog/core/lib/DialogTriggerModel.ts
@@ -18,10 +18,6 @@ export class DialogTriggerModel extends ComponentModel<
 	DialogTriggerModelState,
 	DialogTriggerModelAttributes
 > {
-	deriveInitialState(): DialogTriggerModelState {
-		return {};
-	}
-
 	getType(): DialogComponentType {
 		return 'trigger';
 	}


### PR DESCRIPTION
# Previous state derivation approach

We were previously using an abstract `deriveInitialState` method that was implemented on subclasses to convert initial options to state.

This was done to simplify state derivation since the root model always started from options, and we could not use methods on the root model before calling `super` to the state model.

## Issues

However, this approach limited us to just using options when deriving state. When deriving component state, it's often useful to refer to the root model's state. Under the previous model, it would add unwanted type complexity to include the root model as part of initial options.

It also polluted the state model class with odd references to options which required a `TOption` generic.

## Updated solution

In the new approach, we simply derive state manually in the constructor of `RootModel` and `ComponentModel`, then pass that initial state into the constructor of `StateModel`.

This way, `StateModel` only needs to be concerned with initial state and updates to state.