### PR TITLE
Dialog force mount content

### DIFF
--- a/packages/common/core/lib/ComponentModel.ts
+++ b/packages/common/core/lib/ComponentModel.ts
@@ -3,9 +3,10 @@ import {StateModel} from './StateModel';
 
 export abstract class ComponentModel<
 	TRootModel extends RootModel = any,
-	TOptions = any,
-	TState = any,
-	TAttributes = any,
+	TOptions extends object = any,
+	TState extends object = any,
+	TDerived extends object = any,
+	TAttributes extends object = any,
 > extends StateModel<TState> {
 	rootModel: TRootModel;
 	options: TOptions;
@@ -24,6 +25,10 @@ export abstract class ComponentModel<
 		this.type = this.getType();
 	}
 
+	abstract getType(): $ComponentTypeOf<TRootModel>;
+
+	deriveState?(_rootState?: $StateOf<TRootModel>, _state?: TState): TDerived;
+
 	getId() {
 		return this.getType();
 	}
@@ -32,9 +37,10 @@ export abstract class ComponentModel<
 		return `${this.rootModel.domId()}-${this.getType()}`;
 	}
 
-	getAttributes(_rootState?: $StateOf<TRootModel>): TAttributes {
+	getAttributes(
+		_rootState?: $StateOf<TRootModel>,
+		_state?: TState,
+	): TAttributes {
 		return {} as TAttributes;
 	}
-
-	abstract getType(): $ComponentTypeOf<TRootModel>;
 }

--- a/packages/common/core/lib/RootModel.ts
+++ b/packages/common/core/lib/RootModel.ts
@@ -2,12 +2,10 @@ import type {ComponentModel} from './ComponentModel';
 import {StateModel} from './StateModel';
 import {findLastInMap} from './utils/map';
 
-export interface RootOptions {}
-
 export abstract class RootModel<
 	TComponentType extends string = any,
-	TOptions extends RootOptions = any,
-	TState = any,
+	TOptions extends object = any,
+	TState extends object = any,
 > extends StateModel<TState> {
 	id: string;
 	options: TOptions;

--- a/packages/dialog/core/lib/DialogCloseModel.ts
+++ b/packages/dialog/core/lib/DialogCloseModel.ts
@@ -5,12 +5,15 @@ export interface DialogCloseModelOptions {}
 
 export interface DialogCloseModelState {}
 
+export interface DialogCloseModelDerived {}
+
 export interface DialogCloseModelAttributes {}
 
 export class DialogCloseModel extends ComponentModel<
 	DialogRootModel,
 	DialogCloseModelOptions,
 	DialogCloseModelState,
+	DialogCloseModelDerived,
 	DialogCloseModelAttributes
 > {
 	getType(): DialogComponentType {

--- a/packages/dialog/core/lib/DialogContentModel.ts
+++ b/packages/dialog/core/lib/DialogContentModel.ts
@@ -5,9 +5,15 @@ import type {
 	DialogRootModelState,
 } from './DialogRootModel';
 
-export interface DialogContentModelOptions {}
+export interface DialogContentModelOptions {
+	forceMount?: boolean;
+}
 
 export interface DialogContentModelState {}
+
+export interface DialogContentModelDerived {
+	show: boolean;
+}
 
 export interface DialogContentModelAttributes {
 	id: string;
@@ -22,10 +28,17 @@ export class DialogContentModel extends ComponentModel<
 	DialogRootModel,
 	DialogContentModelOptions,
 	DialogContentModelState,
+	DialogContentModelDerived,
 	DialogContentModelAttributes
 > {
 	getType(): DialogComponentType {
 		return 'content';
+	}
+
+	deriveState(rootState: DialogRootModelState): DialogContentModelDerived {
+		return {
+			show: this.options.forceMount || rootState.open,
+		};
 	}
 
 	getAttributes(rootState: DialogRootModelState): DialogContentModelAttributes {

--- a/packages/dialog/core/lib/DialogDescriptionModel.ts
+++ b/packages/dialog/core/lib/DialogDescriptionModel.ts
@@ -5,6 +5,8 @@ export interface DialogDescriptionModelOptions {}
 
 export interface DialogDescriptionModelState {}
 
+export interface DialogDescriptionModelDerived {}
+
 export interface DialogDescriptionModelAttributes {
 	id: string;
 }
@@ -13,6 +15,7 @@ export class DialogDescriptionModel extends ComponentModel<
 	DialogRootModel,
 	DialogDescriptionModelOptions,
 	DialogDescriptionModelState,
+	DialogDescriptionModelDerived,
 	DialogDescriptionModelAttributes
 > {
 	getType(): DialogComponentType {

--- a/packages/dialog/core/lib/DialogRootModel.ts
+++ b/packages/dialog/core/lib/DialogRootModel.ts
@@ -1,4 +1,4 @@
-import {ComponentModel, RootModel, RootOptions} from '@ally-ui/core';
+import {ComponentModel, RootModel} from '@ally-ui/core';
 import {FocusTrapModel} from '@ally-ui/focus-trap';
 
 export type DialogComponentType =
@@ -8,7 +8,7 @@ export type DialogComponentType =
 	| 'description'
 	| 'close';
 
-export interface DialogRootModelOptions extends RootOptions {
+export interface DialogRootModelOptions {
 	initialOpen?: boolean;
 	modal?: boolean;
 }

--- a/packages/dialog/core/lib/DialogRootModel.ts
+++ b/packages/dialog/core/lib/DialogRootModel.ts
@@ -63,7 +63,7 @@ This provides the user with a recognizable name for the dialog by enforcing an e
 
 	#waitingToOpen = false;
 	#contentTrap?: FocusTrapModel;
-	async #onOpenChangeEffect(open: boolean) {
+	#onOpenChangeEffect(open: boolean) {
 		const handleOpen = () => {
 			const content = this.findComponent(
 				(c) => c.type === 'content' && c.node !== undefined,

--- a/packages/dialog/core/lib/DialogTitleModel.ts
+++ b/packages/dialog/core/lib/DialogTitleModel.ts
@@ -5,6 +5,8 @@ export interface DialogTitleModelOptions {}
 
 export interface DialogTitleModelState {}
 
+export interface DialogTitleModelDerived {}
+
 export interface DialogTitleModelAttributes {
 	id: string;
 }
@@ -13,6 +15,7 @@ export class DialogTitleModel extends ComponentModel<
 	DialogRootModel,
 	DialogTitleModelOptions,
 	DialogTitleModelState,
+	DialogTitleModelDerived,
 	DialogTitleModelAttributes
 > {
 	getType(): DialogComponentType {

--- a/packages/dialog/core/lib/DialogTriggerModel.ts
+++ b/packages/dialog/core/lib/DialogTriggerModel.ts
@@ -5,6 +5,8 @@ export interface DialogTriggerModelOptions {}
 
 export interface DialogTriggerModelState {}
 
+export interface DialogTriggerModelDerived {}
+
 export interface DialogTriggerModelAttributes {
 	id: string;
 	'aria-haspopup': 'dialog';
@@ -16,6 +18,7 @@ export class DialogTriggerModel extends ComponentModel<
 	DialogRootModel,
 	DialogTriggerModelOptions,
 	DialogTriggerModelState,
+	DialogTriggerModelDerived,
 	DialogTriggerModelAttributes
 > {
 	getType(): DialogComponentType {

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
 					<Dialog.Trigger>Edit profile</Dialog.Trigger>
 					{open && <span>Editing profile...</span>}
 				</div>
-				<Dialog.Content asChild>
+				<Dialog.Content asChild forceMount>
 					{(props) => (
 						<section {...props}>
 							<Dialog.Title ref={titleRef} asChild>

--- a/packages/dialog/react/tests/content-force-mount.test.tsx
+++ b/packages/dialog/react/tests/content-force-mount.test.tsx
@@ -1,0 +1,38 @@
+import {cleanup, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Dialog from '../lib/main';
+
+function ContentForceMount() {
+	return (
+		<React.StrictMode>
+			<Dialog.Root>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content" forceMount>
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
+		</React.StrictMode>
+	);
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+it('keeps content open while still managing focus', async () => {
+	const user = userEvent.setup();
+	render(<ContentForceMount />);
+	const content = screen.queryByTestId('content');
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+	await user.click(screen.getByTestId('trigger'));
+	expect(content).toHaveFocusWithin();
+	await user.click(screen.getByTestId('close'));
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+});

--- a/packages/dialog/solid/example/App.tsx
+++ b/packages/dialog/solid/example/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
 						<span>Editing profile...</span>
 					</Show>
 				</div>
-				<Dialog.Content asChild>
+				<Dialog.Content asChild forceMount>
 					{(props) => (
 						<section {...props()}>
 							<Dialog.Title ref={titleRef} asChild>

--- a/packages/dialog/solid/lib/DialogContent.tsx
+++ b/packages/dialog/solid/lib/DialogContent.tsx
@@ -46,7 +46,7 @@ export default function DialogContent(props: DialogContentProps) {
 				rootModel.bindComponent(id, node);
 			}
 		},
-		() => rootState.open,
+		() => derivedState().show,
 	);
 	const ref = combinedRef(bindRef, props.ref);
 

--- a/packages/dialog/solid/lib/DialogContent.tsx
+++ b/packages/dialog/solid/lib/DialogContent.tsx
@@ -1,6 +1,7 @@
 import {
 	DialogContentModel,
 	DialogContentModelAttributes,
+	DialogContentModelOptions,
 } from '@ally-ui/core-dialog';
 import {
 	combinedRef,
@@ -14,7 +15,8 @@ import {useDialogRootModel, useDialogRootState} from './context';
 export type DialogContentProps = SlottableProps<
 	DialogContentModelAttributes,
 	JSX.HTMLAttributes<HTMLDivElement>
->;
+> &
+	DialogContentModelOptions;
 
 export default function DialogContent(props: DialogContentProps) {
 	const rootModel = useDialogRootModel();
@@ -22,11 +24,12 @@ export default function DialogContent(props: DialogContentProps) {
 		throw new Error('<Dialog.Content/> must be a child of `<Dialog.Root/>`');
 	}
 	const component = rootModel.registerComponent(
-		new DialogContentModel(rootModel, {}),
+		new DialogContentModel(rootModel, {forceMount: props.forceMount}),
 	);
 	const id = component.getId();
 
 	const rootState = useDialogRootState() ?? rootModel.getState();
+	const derivedState = () => component.deriveState(rootState);
 
 	onMount(() => {
 		rootModel.mountComponent(id);
@@ -48,7 +51,7 @@ export default function DialogContent(props: DialogContentProps) {
 	const ref = combinedRef(bindRef, props.ref);
 
 	return (
-		<Show when={rootState.open}>
+		<Show when={derivedState().show}>
 			<Slot
 				ref={ref}
 				props={props}

--- a/packages/dialog/solid/tests/content-force-mount.test.tsx
+++ b/packages/dialog/solid/tests/content-force-mount.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from '@testing-library/user-event';
+import {cleanup, render, screen} from 'solid-testing-library';
+import Dialog from '../lib/main';
+
+function ContentForceMount() {
+	return (
+		<Dialog.Root>
+			<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+			<Dialog.Content data-testid="content" forceMount>
+				<Dialog.Title data-testid="title">title</Dialog.Title>
+				<Dialog.Description data-testid="description">
+					description
+				</Dialog.Description>
+				<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+it('keeps content open while still managing focus', async () => {
+	const user = userEvent.setup();
+	render(() => <ContentForceMount />);
+	const content = screen.queryByTestId('content');
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+	await user.click(screen.getByTestId('trigger'));
+	expect(content).toHaveFocusWithin();
+	await user.click(screen.getByTestId('close'));
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+});

--- a/packages/dialog/svelte/example/App.svelte
+++ b/packages/dialog/svelte/example/App.svelte
@@ -18,7 +18,7 @@
 				<span>Editing profile...</span>
 			{/if}
 		</div>
-		<Dialog.Content asChild let:props let:ref>
+		<Dialog.Content asChild let:props let:ref forceMount>
 			<section {...props} use:ref>
 				<Dialog.Title bind:node={titleNode} asChild let:props let:ref>
 					<h2 {...props} use:ref>Edit profile</h2>

--- a/packages/dialog/svelte/lib/DialogContent.svelte
+++ b/packages/dialog/svelte/lib/DialogContent.svelte
@@ -1,9 +1,10 @@
 <script lang="ts" context="module">
 	type DialogContentProps<TAsChild extends true | undefined> =
-		svelteHTML.IntrinsicElements['div'] & {
-			node?: HTMLDivElement | undefined | null;
-			asChild?: TAsChild;
-		};
+		DialogContentModelOptions &
+			svelteHTML.IntrinsicElements['div'] & {
+				node?: HTMLDivElement | undefined | null;
+				asChild?: TAsChild;
+			};
 	type DialogContentSlots<TAsChild extends true | undefined> = {
 		default: DefaultSlot<TAsChild, DialogContentModelAttributes, RefAction>;
 	};
@@ -13,6 +14,7 @@
 	import {
 		DialogContentModel,
 		type DialogContentModelAttributes,
+		type DialogContentModelOptions,
 	} from '@ally-ui/core-dialog';
 	import {
 		createEventForwarder,
@@ -32,12 +34,14 @@
 	if (rootModel === undefined) {
 		throw new Error('<Dialog.Content/> must be a child of `<Dialog.Root/>`');
 	}
+	export let forceMount: boolean | undefined = undefined;
 	const component = rootModel.registerComponent(
-		new DialogContentModel(rootModel, {}),
+		new DialogContentModel(rootModel, {forceMount}),
 	);
 	const id = component.getId();
 
 	const rootState = getDialogRootState() ?? readable(rootModel.getState());
+	$: derivedState = component.deriveState($rootState);
 
 	onMount(() => {
 		rootModel.mountComponent(id);
@@ -68,8 +72,7 @@
 	const eventForwarder = createEventForwarder(get_current_component());
 </script>
 
-<!-- TODO #30 Use derived state on content component. -->
-{#if $rootState.open}
+{#if derivedState.show}
 	{#if asChild}
 		<slot {...slotProps} />
 	{:else}

--- a/packages/dialog/svelte/tests/content-force-mount.test.svelte
+++ b/packages/dialog/svelte/tests/content-force-mount.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import Dialog from '../lib/main';
+</script>
+
+<Dialog.Root>
+	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+	<Dialog.Content data-testid="content" forceMount>
+		<Dialog.Title data-testid="title">title</Dialog.Title>
+		<Dialog.Description data-testid="description">
+			description
+		</Dialog.Description>
+		<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+	</Dialog.Content>
+</Dialog.Root>

--- a/packages/dialog/svelte/tests/content-force-mount.test.ts
+++ b/packages/dialog/svelte/tests/content-force-mount.test.ts
@@ -1,0 +1,20 @@
+import {cleanup, render, screen} from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ContentForceMount from './content-force-mount.test.svelte';
+
+afterEach(async () => {
+	cleanup();
+});
+
+it('keeps content open while still managing focus', async () => {
+	const user = userEvent.setup();
+	render(ContentForceMount);
+	const content = screen.queryByTestId('content');
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+	await user.click(screen.getByTestId('trigger'));
+	expect(content).toHaveFocusWithin();
+	await user.click(screen.getByTestId('close'));
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+});

--- a/packages/dialog/svelte/vitest.global.setup.ts
+++ b/packages/dialog/svelte/vitest.global.setup.ts
@@ -38,7 +38,7 @@ async function createTestServer() {
 				.end(rendered.html);
 		} catch (err: any) {
 			vite.ssrFixStacktrace(err);
-			console.log(err.stack);
+			console.error(err.stack);
 			response.status(500).end(err.stack);
 		}
 	});

--- a/packages/dialog/vue/example/App.vue
+++ b/packages/dialog/vue/example/App.vue
@@ -20,7 +20,7 @@ watchEffect(() => {
 				<Dialog.Trigger>Edit profile</Dialog.Trigger>
 				<span v-if="open">Editing profile...</span>
 			</div>
-			<Dialog.Content as-child v-slot="props">
+			<Dialog.Content as-child v-slot="props" force-mount>
 				<section v-bind="props">
 					<Dialog.Title
 						as-child

--- a/packages/dialog/vue/tests/content-force-mount.test.ts
+++ b/packages/dialog/vue/tests/content-force-mount.test.ts
@@ -1,0 +1,20 @@
+import userEvent from '@testing-library/user-event';
+import {cleanup, render, screen} from '@testing-library/vue';
+import ContentForceMount from './content-force-mount.test.vue';
+
+afterEach(() => {
+	cleanup();
+});
+
+it('keeps content open while still managing focus', async () => {
+	const user = userEvent.setup();
+	render(ContentForceMount);
+	const content = screen.queryByTestId('content');
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+	await user.click(screen.getByTestId('trigger'));
+	expect(content).toHaveFocusWithin();
+	await user.click(screen.getByTestId('close'));
+	expect(content).not.toBeNull();
+	expect(content).not.toHaveFocusWithin();
+});

--- a/packages/dialog/vue/tests/content-force-mount.test.vue
+++ b/packages/dialog/vue/tests/content-force-mount.test.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import Dialog from '../lib/main';
+</script>
+
+<template>
+	<Dialog.Root>
+		<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+		<Dialog.Content data-testid="content" force-mount>
+			<Dialog.Title data-testid="title">title</Dialog.Title>
+			<Dialog.Description data-testid="description">
+				description
+			</Dialog.Description>
+			<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+		</Dialog.Content>
+	</Dialog.Root>
+</template>


### PR DESCRIPTION
Allow the user to force the content to be mounted regardless of open/closed state.

This allows users to manually handle mounting / unmounting for animation libraries.