### PR TITLE
Dynamic `modal` option sync

### DIFF
--- a/packages/common/react/lib/useSyncedOption.tsx
+++ b/packages/common/react/lib/useSyncedOption.tsx
@@ -9,7 +9,7 @@ export interface UseSyncedOptionOptions<TOption> {
 	/**
 	 * The internal option value. This should be derived from internal state.
 	 */
-	internal: TOption;
+	internal?: TOption;
 	/**
 	 * Called with the new external option's value when it changes.
 	 *
@@ -59,7 +59,9 @@ export function useSyncedOption<TOption>({
 	);
 	React.useEffect(
 		function updateOption() {
-			onInternalChange?.(internal);
+			if (internal !== undefined) {
+				onInternalChange?.(internal);
+			}
 		},
 		[internal],
 	);

--- a/packages/common/solid/lib/createSyncedOption.tsx
+++ b/packages/common/solid/lib/createSyncedOption.tsx
@@ -8,7 +8,7 @@ export interface CreateSyncedOptionOptions<TOption> {
 	/**
 	 * An accessor to the internal option value. This should be derived from internal state.
 	 */
-	internal: Accessor<Exclude<TOption, Function>>;
+	internal?: Accessor<Exclude<TOption, Function>>;
 	/**
 	 * Called with the new external option's value when it changes.
 	 *
@@ -33,7 +33,11 @@ export function createSyncedOption<TOption>({
 	onInternalChange,
 }: CreateSyncedOptionOptions<TOption>) {
 	const untrackedOption = untrack(option);
-	if (untrackedOption !== undefined && untrackedOption !== untrack(internal)) {
+	if (
+		untrackedOption !== undefined &&
+		internal !== undefined &&
+		untrackedOption !== untrack(internal)
+	) {
 		onOptionChange(untrackedOption);
 	}
 	let previousOption = untrackedOption;
@@ -54,7 +58,9 @@ export function createSyncedOption<TOption>({
 	);
 	createEffect(
 		function updateOption() {
-			onInternalChange?.(internal());
+			if (internal !== undefined) {
+				onInternalChange?.(internal());
+			}
 		},
 		[internal],
 	);

--- a/packages/common/svelte/lib/createSyncedOption.ts
+++ b/packages/common/svelte/lib/createSyncedOption.ts
@@ -10,7 +10,7 @@ export interface CreateSyncedOptionOptions<TOption> {
 	/**
 	 * The internal option value. This should be derived from internal state.
 	 */
-	internal: Readable<TOption>;
+	internal?: Readable<TOption>;
 	/**
 	 * Called with the new external option's value when it changes.
 	 *
@@ -38,13 +38,13 @@ export function createSyncedOption<TOption>({
 		previousOption = $option;
 		onOptionChange($option);
 	});
-	const unsubcribeInternal = internal.subscribe(($internal) => {
+	const unsubcribeInternal = internal?.subscribe(($internal) => {
 		if (isWritable(option)) {
 			option.set($internal);
 		}
 	});
 	onDestroy(() => {
-		unsubcribeInternal();
+		unsubcribeInternal?.();
 		unsubcribeOption?.();
 	});
 }

--- a/packages/common/vue/lib/useSyncedOption.ts
+++ b/packages/common/vue/lib/useSyncedOption.ts
@@ -8,7 +8,7 @@ export interface UseSyncedOptionOptions<TOption> {
 	/**
 	 * A ref of the internal option value. This should be derived from internal state.
 	 */
-	internal: Ref<TOption>;
+	internal?: Ref<TOption>;
 	/**
 	 * Called with the new external option's value when it changes.
 	 *
@@ -48,6 +48,9 @@ export function useSyncedOption<TOption>({
 	});
 	watchEffect(function updateOption() {
 		if (option === undefined) {
+			return;
+		}
+		if (internal === undefined) {
 			return;
 		}
 		if (internal.value === previousOption) {

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -40,6 +40,11 @@ export default function DialogRoot({
 		internal: rootState.open,
 		onInternalChange: onOpenChange,
 	});
+	useSyncedOption({
+		option: modal,
+		onOptionChange: (modal) =>
+			setRootState((prevState) => ({...prevState, modal})),
+	});
 	React.useEffect(
 		function onStateUpdate() {
 			rootModel.setState(rootState);

--- a/packages/dialog/react/tests/attributes.test.tsx
+++ b/packages/dialog/react/tests/attributes.test.tsx
@@ -37,13 +37,6 @@ describe('content', () => {
 		expect(content).toHaveAttribute('aria-modal', 'true');
 	});
 
-	it('renders basic aria attributes for a non-modal dialog', () => {
-		render(<Attributes initialOpen modal={false} />);
-		const content = screen.getByTestId('content');
-		expect(content).toHaveAttribute('role', 'dialog');
-		expect(content).not.toHaveAttribute('aria-modal');
-	});
-
 	it('renders aria attributes that point to title and description', () => {
 		render(<Attributes initialOpen />);
 		const content = screen.getByTestId('content');

--- a/packages/dialog/react/tests/modal-non-modal.test.tsx
+++ b/packages/dialog/react/tests/modal-non-modal.test.tsx
@@ -1,0 +1,50 @@
+import {cleanup, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Dialog from '../lib/main';
+
+interface ModalNonModalProps {
+	initialModal: boolean;
+}
+
+function ModalNonModal({initialModal}: ModalNonModalProps) {
+	const [modal, setModal] = React.useState(initialModal);
+	return (
+		<React.StrictMode>
+			<button onClick={() => setModal((m) => !m)} data-testid="toggle-modal">
+				modal
+			</button>
+			<Dialog.Root modal={modal}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content" forceMount>
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
+		</React.StrictMode>
+	);
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+it('removes the aria-modal attribute for non-modal dialogs', () => {
+	render(<ModalNonModal initialModal={false} />);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+});
+
+it('toggles the aria-modal attribute', async () => {
+	const user = userEvent.setup();
+	render(<ModalNonModal initialModal={false} />);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).toHaveAttribute('aria-modal', 'true');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).not.toHaveAttribute('aria-modal');
+});

--- a/packages/dialog/solid/lib/DialogRoot.tsx
+++ b/packages/dialog/solid/lib/DialogRoot.tsx
@@ -30,6 +30,11 @@ export default function DialogRoot(props: DialogRootProps) {
 		internal: () => rootState.open,
 		onInternalChange: props.onOpenChange,
 	});
+	createSyncedOption({
+		option: () => props.modal,
+		onOptionChange: (modal) =>
+			setRootState((prevState) => ({...prevState, modal})),
+	});
 	createEffect(function onStateUpdate() {
 		rootModel.setState({...rootState});
 	});

--- a/packages/dialog/solid/tests/attributes.test.tsx
+++ b/packages/dialog/solid/tests/attributes.test.tsx
@@ -34,13 +34,6 @@ describe('content', () => {
 		expect(content).toHaveAttribute('aria-modal', 'true');
 	});
 
-	it('renders basic aria attributes for a non-modal dialog', () => {
-		render(() => <Attributes initialOpen modal={false} />);
-		const content = screen.getByTestId('content');
-		expect(content).toHaveAttribute('role', 'dialog');
-		expect(content).not.toHaveAttribute('aria-modal');
-	});
-
 	it('renders aria attributes that point to title and description', () => {
 		render(() => <Attributes initialOpen />);
 		const content = screen.getByTestId('content');

--- a/packages/dialog/solid/tests/modal-non-modal.test.tsx
+++ b/packages/dialog/solid/tests/modal-non-modal.test.tsx
@@ -1,0 +1,50 @@
+import userEvent from '@testing-library/user-event';
+import {createSignal} from 'solid-js';
+import {cleanup, render, screen} from 'solid-testing-library';
+import Dialog from '../lib/main';
+
+interface ModalNonModalProps {
+	initialModal: boolean;
+}
+
+function ModalNonModal({initialModal}: ModalNonModalProps) {
+	const [modal, setModal] = createSignal(initialModal);
+	return (
+		<>
+			<button onClick={() => setModal((m) => !m)} data-testid="toggle-modal">
+				modal
+			</button>
+			<Dialog.Root modal={modal()}>
+				<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+				<Dialog.Content data-testid="content" forceMount>
+					<Dialog.Title data-testid="title">title</Dialog.Title>
+					<Dialog.Description data-testid="description">
+						description
+					</Dialog.Description>
+					<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+				</Dialog.Content>
+			</Dialog.Root>
+		</>
+	);
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+it('removes the aria-modal attribute for non-modal dialogs', () => {
+	render(() => <ModalNonModal initialModal={false} />);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+});
+
+it('toggles the aria-modal attribute', async () => {
+	const user = userEvent.setup();
+	render(() => <ModalNonModal initialModal={false} />);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).toHaveAttribute('aria-modal', 'true');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).not.toHaveAttribute('aria-modal');
+});

--- a/packages/dialog/svelte/lib/DialogRoot.svelte
+++ b/packages/dialog/svelte/lib/DialogRoot.svelte
@@ -15,13 +15,15 @@
 
 	type $$Props = DialogRootProps;
 
+	export let initialOpen: boolean | undefined = undefined;
 	export let open: boolean | undefined = undefined;
 	const openStore = writable(open);
 	const watchOpen = bindStore(openStore, (o) => (open = o));
 	$: watchOpen(open);
-
-	export let initialOpen: boolean | undefined = undefined;
 	export let modal: boolean | undefined = undefined;
+	const modalStore = writable(modal);
+	const watchModal = bindStore(modalStore, (m) => (modal = m));
+	$: watchModal(modal);
 
 	// TODO #19 Generate SSR-safe IDs.
 	const id = '0';
@@ -42,6 +44,11 @@
 		onOptionChange: ($open) =>
 			rootState.update((prevState) => ({...prevState, open: $open})),
 		internal: derived(rootState, ($state) => $state.open),
+	});
+	createSyncedOption({
+		option: modalStore,
+		onOptionChange: ($modal) =>
+			rootState.update((prevState) => ({...prevState, modal: $modal})),
 	});
 	$: rootModel.setState($rootState);
 

--- a/packages/dialog/svelte/tests/attributes.test.ts
+++ b/packages/dialog/svelte/tests/attributes.test.ts
@@ -19,13 +19,6 @@ describe('content', () => {
 		expect(content).toHaveAttribute('aria-modal', 'true');
 	});
 
-	it('renders basic aria attributes for a non-modal dialog', () => {
-		render(Attributes, {initialOpen: true, modal: false});
-		const content = screen.getByTestId('content');
-		expect(content).toHaveAttribute('role', 'dialog');
-		expect(content).not.toHaveAttribute('aria-modal');
-	});
-
 	it('renders aria attributes that point to title and description', () => {
 		render(Attributes, {initialOpen: true});
 		const content = screen.getByTestId('content');

--- a/packages/dialog/svelte/tests/modal-non-modal.test.svelte
+++ b/packages/dialog/svelte/tests/modal-non-modal.test.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Dialog from '../lib/main';
+
+	let modal = false;
+</script>
+
+<button on:click={() => (modal = !modal)} data-testid="toggle-modal">
+	modal
+</button>
+<Dialog.Root {modal}>
+	<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+	<Dialog.Content data-testid="content" forceMount>
+		<Dialog.Title data-testid="title">title</Dialog.Title>
+		<Dialog.Description data-testid="description">
+			description
+		</Dialog.Description>
+		<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+	</Dialog.Content>
+</Dialog.Root>

--- a/packages/dialog/svelte/tests/modal-non-modal.test.ts
+++ b/packages/dialog/svelte/tests/modal-non-modal.test.ts
@@ -1,0 +1,24 @@
+import {cleanup, render, screen} from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import ModalNonModal from './modal-non-modal.test.svelte';
+
+afterEach(async () => {
+	cleanup();
+});
+
+it('removes the aria-modal attribute for non-modal dialogs', () => {
+	render(ModalNonModal);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+});
+
+it('toggles the aria-modal attribute', async () => {
+	const user = userEvent.setup();
+	render(ModalNonModal);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).toHaveAttribute('aria-modal', 'true');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).not.toHaveAttribute('aria-modal');
+});

--- a/packages/dialog/vue/lib/DialogRoot.vue
+++ b/packages/dialog/vue/lib/DialogRoot.vue
@@ -41,6 +41,10 @@ useSyncedOption({
 	internal: computed(() => rootState.value.open),
 	onInternalChange: (open) => emit('update:open', open),
 });
+useSyncedOption({
+	option: computed(() => props.modal),
+	onOptionChange: (modal) => (rootState.value = {...rootState.value, modal}),
+});
 watchEffect(function onStateUpdate() {
 	rootModel.setState(rootState.value);
 });

--- a/packages/dialog/vue/tests/attributes.test.ts
+++ b/packages/dialog/vue/tests/attributes.test.ts
@@ -19,13 +19,6 @@ describe('content', () => {
 		expect(content).toHaveAttribute('aria-modal', 'true');
 	});
 
-	it('renders basic aria attributes for a non-modal dialog', () => {
-		render(Attributes, {props: {initialOpen: true, modal: false}});
-		const content = screen.getByTestId('content');
-		expect(content).toHaveAttribute('role', 'dialog');
-		expect(content).not.toHaveAttribute('aria-modal');
-	});
-
 	it('renders aria attributes that point to title and description', () => {
 		render(Attributes, {props: {initialOpen: true}});
 		const content = screen.getByTestId('content');

--- a/packages/dialog/vue/tests/modal-non-modal.test.ts
+++ b/packages/dialog/vue/tests/modal-non-modal.test.ts
@@ -1,0 +1,24 @@
+import userEvent from '@testing-library/user-event';
+import {cleanup, render, screen} from '@testing-library/vue';
+import ModalNonModal from './modal-non-modal.test.vue';
+
+afterEach(async () => {
+	cleanup();
+});
+
+it('removes the aria-modal attribute for non-modal dialogs', () => {
+	render(ModalNonModal);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+});
+
+it('toggles the aria-modal attribute', async () => {
+	const user = userEvent.setup();
+	render(ModalNonModal);
+	const content = screen.getByTestId('content');
+	expect(content).not.toHaveAttribute('aria-modal');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).toHaveAttribute('aria-modal', 'true');
+	await user.click(screen.getByTestId('toggle-modal'));
+	expect(content).not.toHaveAttribute('aria-modal');
+});

--- a/packages/dialog/vue/tests/modal-non-modal.test.vue
+++ b/packages/dialog/vue/tests/modal-non-modal.test.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import {ref} from 'vue';
+import Dialog from '../lib/main';
+
+const modal = ref(false);
+</script>
+
+<template>
+	<button @click="() => (modal = !modal)" data-testid="toggle-modal">
+		modal
+	</button>
+	<Dialog.Root :modal="modal">
+		<Dialog.Trigger data-testid="trigger">open dialog</Dialog.Trigger>
+		<Dialog.Content data-testid="content" force-mount>
+			<Dialog.Title data-testid="title">title</Dialog.Title>
+			<Dialog.Description data-testid="description">
+				description
+			</Dialog.Description>
+			<Dialog.Close data-testid="close">close dialog</Dialog.Close>
+		</Dialog.Content>
+	</Dialog.Root>
+</template>


### PR DESCRIPTION
Allow the modal property to be updated dynamically.

While this does not have any functional uses right now, it serves as a proof-of-concept for one-way option syncing.