### PR TITLE
[Dialog] Customize focus trap behaviour

### DIFF
--- a/packages/common/solid/lib/createSyncedOption.tsx
+++ b/packages/common/solid/lib/createSyncedOption.tsx
@@ -4,11 +4,11 @@ export interface CreateSyncedOptionOptions<TOption> {
 	/**
 	 * An accessor to the external option value.
 	 */
-	option: Accessor<Exclude<TOption, Function> | undefined>;
+	option: Accessor<TOption | undefined>;
 	/**
 	 * An accessor to the internal option value. This should be derived from internal state.
 	 */
-	internal?: Accessor<Exclude<TOption, Function>>;
+	internal?: Accessor<TOption>;
 	/**
 	 * Called with the new external option's value when it changes.
 	 *

--- a/packages/dialog/core/lib/DialogRootModel.ts
+++ b/packages/dialog/core/lib/DialogRootModel.ts
@@ -58,11 +58,34 @@ This provides the user with a recognizable name for the dialog by enforcing an e
 	}
 
 	watchStateChange(
-		newState: DialogRootModelReactive,
-		prevState: DialogRootModelReactive,
+		{
+			open,
+			clickOutsideDeactivates,
+			escapeDeactivates,
+			returnFocusTo,
+		}: DialogRootModelState,
+		prevState: DialogRootModelState,
 	) {
-		if (newState.open !== prevState.open) {
-			this.#onOpenChangeEffect(newState.open);
+		if (open !== prevState.open) {
+			this.#onOpenChangeEffect(open);
+		}
+		if (clickOutsideDeactivates !== prevState.clickOutsideDeactivates) {
+			this.#contentTrap?.setState({
+				...this.#contentTrap.state,
+				clickOutsideDeactivates,
+			});
+		}
+		if (escapeDeactivates !== prevState.escapeDeactivates) {
+			this.#contentTrap?.setState({
+				...this.#contentTrap.state,
+				escapeDeactivates,
+			});
+		}
+		if (returnFocusTo !== prevState.returnFocusTo) {
+			this.#contentTrap?.setState({
+				...this.#contentTrap.state,
+				returnFocusTo,
+			});
 		}
 	}
 

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -8,16 +8,28 @@ export default function App() {
 			node.style.color = 'gray';
 		}
 	}, []);
+	const [outside, setOutside] = React.useState(false);
+	const [escape, setEscape] = React.useState(true);
+	const [returnFocus, setReturnFocus] = React.useState<HTMLElement | null>(
+		null,
+	);
 
 	return (
 		<main>
+			<button onClick={() => setOutside((o) => !o)} ref={setReturnFocus}>
+				Click outside {outside ? 'deactivates' : 'blocked'}
+			</button>
+			<button onClick={() => setEscape((e) => !e)}>
+				Escape {escape ? 'deactivates' : 'blocked'}
+			</button>
 			<h1>Ally UI React Dialog</h1>
 			<Dialog.Root
 				open={open}
 				onOpenChange={setOpen}
 				initialOpen
-				escapeDeactivates={false}
-				clickOutsideDeactivates
+				clickOutsideDeactivates={outside}
+				escapeDeactivates={escape}
+				returnFocusTo={returnFocus ?? undefined}
 			>
 				<div>
 					<button onClick={() => setOpen((o) => !o)}>Manual toggle</button>

--- a/packages/dialog/react/lib/DialogRoot.tsx
+++ b/packages/dialog/react/lib/DialogRoot.tsx
@@ -17,10 +17,10 @@ export type DialogRootProps = React.PropsWithChildren &
 
 export default function DialogRoot({
 	children,
+	open,
+	onOpenChange,
 	initialOpen,
 	modal,
-	onOpenChange,
-	open,
 	clickOutsideDeactivates,
 	escapeDeactivates,
 	returnFocusTo,
@@ -53,6 +53,21 @@ export default function DialogRoot({
 		option: modal,
 		onOptionChange: (modal) =>
 			setRootState((prevState) => ({...prevState, modal})),
+	});
+	useSyncedOption({
+		option: clickOutsideDeactivates,
+		onOptionChange: (clickOutsideDeactivates) =>
+			setRootState((prevState) => ({...prevState, clickOutsideDeactivates})),
+	});
+	useSyncedOption({
+		option: escapeDeactivates,
+		onOptionChange: (escapeDeactivates) =>
+			setRootState((prevState) => ({...prevState, escapeDeactivates})),
+	});
+	useSyncedOption({
+		option: returnFocusTo,
+		onOptionChange: (returnFocusTo) =>
+			setRootState((prevState) => ({...prevState, returnFocusTo})),
 	});
 	React.useEffect(
 		function onStateUpdate() {

--- a/packages/dialog/solid/example/App.tsx
+++ b/packages/dialog/solid/example/App.tsx
@@ -6,11 +6,27 @@ export default function App() {
 	const titleRef = (node: HTMLElement) => {
 		node.style.color = 'gray';
 	};
+	const [outside, setOutside] = createSignal(false);
+	const [escape, setEscape] = createSignal(true);
+	const [returnFocus, setReturnFocus] = createSignal<HTMLElement | null>(null);
 
 	return (
 		<main>
+			<button onClick={() => setOutside((o) => !o)} ref={setReturnFocus}>
+				Click outside {outside() ? 'deactivates' : 'blocked'}
+			</button>
+			<button onClick={() => setEscape((e) => !e)}>
+				Escape {escape() ? 'deactivates' : 'blocked'}
+			</button>
 			<h1>Ally UI Solid Dialog</h1>
-			<Dialog.Root open={open()} onOpenChange={setOpen}>
+			<Dialog.Root
+				open={open()}
+				onOpenChange={setOpen}
+				initialOpen
+				clickOutsideDeactivates={outside()}
+				escapeDeactivates={escape()}
+				returnFocusTo={returnFocus() ?? undefined}
+			>
 				<div>
 					<button onClick={() => setOpen(!open())}>Manual toggle</button>
 					<Dialog.Trigger>Edit profile</Dialog.Trigger>
@@ -18,7 +34,7 @@ export default function App() {
 						<span>Editing profile...</span>
 					</Show>
 				</div>
-				<Dialog.Content asChild forceMount>
+				<Dialog.Content asChild>
 					{(props) => (
 						<section {...props()}>
 							<Dialog.Title ref={titleRef} asChild>

--- a/packages/dialog/solid/lib/DialogRoot.tsx
+++ b/packages/dialog/solid/lib/DialogRoot.tsx
@@ -17,6 +17,9 @@ export default function DialogRoot(props: DialogRootProps) {
 	const rootModel = new DialogRootModel(id, {
 		initialOpen: props.initialOpen,
 		modal: props.modal,
+		clickOutsideDeactivates: props.clickOutsideDeactivates,
+		escapeDeactivates: props.escapeDeactivates,
+		returnFocusTo: props.returnFocusTo,
 	});
 	const [rootState, setRootState] = createStore({...rootModel.initialState});
 	rootModel.requestStateUpdate = setRootState;
@@ -31,6 +34,21 @@ export default function DialogRoot(props: DialogRootProps) {
 		option: () => props.modal,
 		onOptionChange: (modal) =>
 			setRootState((prevState) => ({...prevState, modal})),
+	});
+	createSyncedOption({
+		option: () => props.clickOutsideDeactivates,
+		onOptionChange: (clickOutsideDeactivates) =>
+			setRootState((prevState) => ({...prevState, clickOutsideDeactivates})),
+	});
+	createSyncedOption({
+		option: () => props.escapeDeactivates,
+		onOptionChange: (escapeDeactivates) =>
+			setRootState((prevState) => ({...prevState, escapeDeactivates})),
+	});
+	createSyncedOption({
+		option: () => props.returnFocusTo,
+		onOptionChange: (returnFocusTo) =>
+			setRootState((prevState) => ({...prevState, returnFocusTo})),
 	});
 	createEffect(function onStateUpdate() {
 		rootModel.setState({...rootState});

--- a/packages/dialog/svelte/example/App.svelte
+++ b/packages/dialog/svelte/example/App.svelte
@@ -6,11 +6,26 @@
 	$: if (titleNode != null) {
 		titleNode.style.color = 'gray';
 	}
+	let outside = false;
+	let escape = true;
+	let returnFocus: HTMLElement | null = null;
 </script>
 
 <main>
+	<button on:click={() => (outside = !outside)} bind:this={returnFocus}>
+		Click outside {outside ? 'deactivates' : 'blocked'}
+	</button>
+	<button on:click={() => (escape = !escape)}>
+		Escape {escape ? 'deactivates' : 'blocked'}
+	</button>
 	<h1>Ally UI Svelte Dialog</h1>
-	<Dialog.Root bind:open>
+	<Dialog.Root
+		bind:open
+		initialOpen
+		clickOutsideDeactivates={outside}
+		escapeDeactivates={escape}
+		returnFocusTo={returnFocus ?? null}
+	>
 		<div>
 			<button on:click={() => (open = !open)}>Manual toggle</button>
 			<Dialog.Trigger>Edit profile</Dialog.Trigger>
@@ -18,7 +33,7 @@
 				<span>Editing profile...</span>
 			{/if}
 		</div>
-		<Dialog.Content asChild let:props let:ref forceMount>
+		<Dialog.Content asChild let:props let:ref>
 			<section {...props} use:ref>
 				<Dialog.Title bind:node={titleNode} asChild let:props let:ref>
 					<h2 {...props} use:ref>Edit profile</h2>

--- a/packages/dialog/svelte/lib/DialogRoot.svelte
+++ b/packages/dialog/svelte/lib/DialogRoot.svelte
@@ -15,6 +15,7 @@
 	type $$Props = DialogRootProps;
 
 	export let initialOpen: boolean | undefined = undefined;
+	// TODO #41 Remove unnecessary store overhead for each option.
 	export let open: boolean | undefined = undefined;
 	const openStore = writable(open);
 	const watchOpen = bindStore(openStore, (o) => (open = o));
@@ -23,6 +24,27 @@
 	const modalStore = writable(modal);
 	const watchModal = bindStore(modalStore, (m) => (modal = m));
 	$: watchModal(modal);
+	export let clickOutsideDeactivates: boolean | undefined = undefined;
+	const clickOutsideDeactivatesStore = writable(clickOutsideDeactivates);
+	const watchClickOutsideDeactivates = bindStore(
+		clickOutsideDeactivatesStore,
+		(c) => (clickOutsideDeactivates = c),
+	);
+	$: watchClickOutsideDeactivates(clickOutsideDeactivates);
+	export let escapeDeactivates: boolean | undefined = undefined;
+	const escapeDeactivatesStore = writable(escapeDeactivates);
+	const watchEscapeDeactivates = bindStore(
+		escapeDeactivatesStore,
+		(e) => (escapeDeactivates = e),
+	);
+	$: watchEscapeDeactivates(escapeDeactivates);
+	export let returnFocusTo: HTMLElement | undefined = undefined;
+	const returnFocusToStore = writable(returnFocusTo);
+	const watchReturnFocusTo = bindStore(
+		returnFocusToStore,
+		(r) => (returnFocusTo = r),
+	);
+	$: watchReturnFocusTo(returnFocusTo);
 
 	// TODO #19 Generate SSR-safe IDs.
 	const id = '0';
@@ -37,14 +59,32 @@
 	};
 	createSyncedOption({
 		option: openStore,
-		onOptionChange: ($open) =>
-			rootState.update((prevState) => ({...prevState, open: $open})),
-		internal: derived(rootState, ($state) => $state.open),
+		onOptionChange: (open) =>
+			rootState.update((prevState) => ({...prevState, open})),
+		internal: derived(rootState, ($rootState) => $rootState.open),
 	});
 	createSyncedOption({
 		option: modalStore,
-		onOptionChange: ($modal) =>
-			rootState.update((prevState) => ({...prevState, modal: $modal})),
+		onOptionChange: (modal) =>
+			rootState.update((prevState) => ({...prevState, modal})),
+	});
+	createSyncedOption({
+		option: clickOutsideDeactivatesStore,
+		onOptionChange: (clickOutsideDeactivates) =>
+			rootState.update((prevState) => ({
+				...prevState,
+				clickOutsideDeactivates,
+			})),
+	});
+	createSyncedOption({
+		option: escapeDeactivatesStore,
+		onOptionChange: (escapeDeactivates) =>
+			rootState.update((prevState) => ({...prevState, escapeDeactivates})),
+	});
+	createSyncedOption({
+		option: returnFocusToStore,
+		onOptionChange: (returnFocusTo) =>
+			rootState.update((prevState) => ({...prevState, returnFocusTo})),
 	});
 	$: rootModel.setState($rootState);
 

--- a/packages/dialog/vue/example/App.vue
+++ b/packages/dialog/vue/example/App.vue
@@ -9,18 +9,33 @@ watchEffect(() => {
 		titleRef.value.style.color = 'gray';
 	}
 });
+const outside = ref(false);
+const escape = ref(true);
+const returnFocus = ref<HTMLElement | null>(null);
 </script>
 
 <template>
 	<main>
+		<button @click="() => (outside = !outside)" ref="returnFocus">
+			Click outside {{ outside ? 'deactivates' : 'blocked' }}
+		</button>
+		<button @click="() => (escape = !escape)">
+			Escape {{ escape ? 'deactivates' : 'blocked' }}
+		</button>
 		<h1>Ally UI Vue Dialog</h1>
-		<Dialog.Root v-model:open="open">
+		<Dialog.Root
+			v-model:open="open"
+			initial-open
+			:click-outside-deactivates="outside"
+			:escape-deactivates="escape"
+			:return-focus-to="returnFocus ?? undefined"
+		>
 			<div>
 				<button @click="() => (open = !open)">Manual toggle</button>
 				<Dialog.Trigger>Edit profile</Dialog.Trigger>
 				<span v-if="open">Editing profile...</span>
 			</div>
-			<Dialog.Content as-child v-slot="props" force-mount>
+			<Dialog.Content as-child v-slot="props">
 				<section v-bind="props">
 					<Dialog.Title
 						as-child

--- a/packages/dialog/vue/lib/DialogRoot.vue
+++ b/packages/dialog/vue/lib/DialogRoot.vue
@@ -4,15 +4,25 @@ import {useSyncedOption} from '@ally-ui/vue';
 import {computed, provide, ref, watchEffect} from 'vue';
 import {DIALOG_ROOT_MODEL, DIALOG_ROOT_STATE} from './context';
 
+/**
+ * @type {import('@ally-ui/core-dialog').DialogRootModelOptions}
+ * @type {import('@ally-ui/core-dialog').DialogRootModelReactive}
+ */
 export type DialogRootProps = {
-	open?: boolean;
 	initialOpen?: boolean;
 	modal?: boolean;
+	clickOutsideDeactivates?: boolean | ((ev: MouseEvent) => boolean);
+	escapeDeactivates?: boolean | ((ev: KeyboardEvent) => boolean);
+	returnFocusTo?: HTMLElement | (() => HTMLElement | undefined);
+	open?: boolean;
 };
 const props = withDefaults(defineProps<DialogRootProps>(), {
-	open: undefined,
 	initialOpen: undefined,
 	modal: undefined,
+	clickOutsideDeactivates: undefined,
+	escapeDeactivates: undefined,
+	returnFocusTo: undefined,
+	open: undefined,
 });
 const emit = defineEmits<{
 	(ev: 'update:open', open: boolean): void;
@@ -23,6 +33,9 @@ const id = '0';
 const rootModel = new DialogRootModel(id, {
 	initialOpen: props.initialOpen,
 	modal: props.modal,
+	clickOutsideDeactivates: props.clickOutsideDeactivates,
+	escapeDeactivates: props.escapeDeactivates,
+	returnFocusTo: props.returnFocusTo,
 });
 const rootState = ref(rootModel.initialState);
 rootModel.requestStateUpdate = (updater) => {
@@ -41,6 +54,21 @@ useSyncedOption({
 useSyncedOption({
 	option: computed(() => props.modal),
 	onOptionChange: (modal) => (rootState.value = {...rootState.value, modal}),
+});
+useSyncedOption({
+	option: computed(() => props.clickOutsideDeactivates),
+	onOptionChange: (clickOutsideDeactivates) =>
+		(rootState.value = {...rootState.value, clickOutsideDeactivates}),
+});
+useSyncedOption({
+	option: computed(() => props.escapeDeactivates),
+	onOptionChange: (escapeDeactivates) =>
+		(rootState.value = {...rootState.value, escapeDeactivates}),
+});
+useSyncedOption({
+	option: computed(() => props.returnFocusTo),
+	onOptionChange: (returnFocusTo) =>
+		(rootState.value = {...rootState.value, returnFocusTo}),
 });
 watchEffect(function onStateUpdate() {
 	rootModel.setState(rootState.value);


### PR DESCRIPTION
Pass `clickOutsideDeactivates`, `escapeDeactivates`, and `returnFocusTo` properties through `DialogRoot` and synchronize the options.