### PR TITLE
Render prop getters

### DIFF
--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -47,7 +47,7 @@ export default function App() {
 					}}
 				>
 					{(props) => (
-						<section {...props}>
+						<section {...props()}>
 							<Dialog.Title ref={titleRef} asChild>
 								{(props) => <h2 {...props}>Edit profile</h2>}
 							</Dialog.Title>
@@ -64,7 +64,15 @@ export default function App() {
 							</fieldset>
 							<Dialog.Close>Save changes</Dialog.Close>
 							<Dialog.Close asChild>
-								{(props) => <a {...props}>x</a>}
+								{(props) => (
+									<a
+										{...props({
+											onClick: () => console.log('clicked close'),
+										})}
+									>
+										x
+									</a>
+								)}
 							</Dialog.Close>
 						</section>
 					)}

--- a/packages/dialog/react/lib/DialogClose.tsx
+++ b/packages/dialog/react/lib/DialogClose.tsx
@@ -76,6 +76,14 @@ const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
 					...component.getAttributes(),
 					onClick: handleClick,
 				}}
+				mergeProps={(attributes, userProps) => ({
+					...attributes,
+					...userProps,
+					onClick: (ev) => {
+						userProps.onClick?.(ev);
+						attributes.onClick(ev);
+					},
+				})}
 			>
 				{({ref, children, attributes}) => (
 					<button ref={ref} {...attributes}>

--- a/packages/dialog/react/lib/DialogTrigger.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.tsx
@@ -78,6 +78,14 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 					...component.getAttributes(rootState),
 					onClick: handleClick,
 				}}
+				mergeProps={(attributes, userProps) => ({
+					...attributes,
+					...userProps,
+					onClick: (ev) => {
+						userProps.onClick?.(ev);
+						attributes.onClick(ev);
+					},
+				})}
 			>
 				{({ref, children, attributes}) => (
 					<button ref={ref} {...attributes}>

--- a/packages/dialog/solid/example/App.tsx
+++ b/packages/dialog/solid/example/App.tsx
@@ -62,7 +62,15 @@ export default function App() {
 							</fieldset>
 							<Dialog.Close>Save changes</Dialog.Close>
 							<Dialog.Close asChild>
-								{(props) => <a {...props}>x</a>}
+								{(props) => (
+									<a
+										{...props({
+											onClick: () => console.log('clicked close'),
+										})}
+									>
+										x
+									</a>
+								)}
 							</Dialog.Close>
 						</section>
 					)}

--- a/packages/dialog/solid/lib/DialogClose.tsx
+++ b/packages/dialog/solid/lib/DialogClose.tsx
@@ -65,6 +65,14 @@ export default function DialogClose(props: DialogCloseProps) {
 			ref={ref}
 			props={props}
 			attributes={{...component.getAttributes(), onClick: handleClick}}
+			mergeProps={(attributes, userProps) => ({
+				...attributes,
+				...userProps,
+				onClick: (ev) => {
+					forwardEvent(ev, userProps.onClick);
+					attributes.onClick(ev);
+				},
+			})}
 		>
 			{(renderProps) => (
 				<button ref={renderProps.ref} {...renderProps.attributes()}>

--- a/packages/dialog/solid/lib/DialogTrigger.tsx
+++ b/packages/dialog/solid/lib/DialogTrigger.tsx
@@ -67,6 +67,14 @@ export default function DialogTrigger(props: DialogTriggerProps) {
 			ref={ref}
 			props={props}
 			attributes={{...component.getAttributes(rootState), onClick: handleClick}}
+			mergeProps={(attributes, userProps) => ({
+				...attributes,
+				...userProps,
+				onClick: (ev) => {
+					forwardEvent(ev, userProps.onClick);
+					attributes.onClick(ev);
+				},
+			})}
 		>
 			{(renderProps) => (
 				<button ref={renderProps.ref} {...renderProps.attributes()}>

--- a/packages/dialog/svelte/example/App.svelte
+++ b/packages/dialog/svelte/example/App.svelte
@@ -63,7 +63,13 @@
 				</fieldset>
 				<Dialog.Close>Save changes</Dialog.Close>
 				<Dialog.Close asChild let:props let:ref>
-					<span {...props} use:ref>x</span>
+					<span
+						on:click={() => console.log('clicked close')}
+						{...props}
+						use:ref
+					>
+						x
+					</span>
 				</Dialog.Close>
 			</section>
 		</Dialog.Content>

--- a/packages/dialog/vue/example/App.vue
+++ b/packages/dialog/vue/example/App.vue
@@ -9,6 +9,9 @@ watchEffect(() => {
 		titleRef.value.style.color = 'gray';
 	}
 });
+
+const click = () => console.log('clicked close');
+
 const outside = ref(false);
 const escape = ref(true);
 const returnFocus = ref<HTMLElement | null>(null);
@@ -73,7 +76,9 @@ const returnFocus = ref<HTMLElement | null>(null);
 						<input id="username" placeholder="@bryanmylee" />
 					</fieldset>
 					<Dialog.Close>Save changes</Dialog.Close>
-					<Dialog.Close>x</Dialog.Close>
+					<Dialog.Close as-child v-slot="props">
+						<span v-bind="props" @click="click">x</span>
+					</Dialog.Close>
 				</section>
 			</Dialog.Content>
 		</Dialog.Root>


### PR DESCRIPTION
Instead of passing a plain `props` object as the render prop, we pass a render prop getter.

This allows the component to control how props are merged.

For example, `DialogTrigger` can merge user-supplied props on an as-child component and handle the `onClick` handler to trigger the user-supplied action while still calling its internal handlers.

```tsx
<Dialog.Close asChild>
  {(props) => (
    <a
      {...props({
        onClick: () => console.log('clicked close'),
      })}
    >
      x
    </a>
  )}
</Dialog.Close>
```