### PR TITLE
fix: tssconfig include is always relative to the file

### DIFF
--- a/packages/common/core/tsconfig.json
+++ b/packages/common/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.base.json",
-	"include": ["lib"],
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/dev/tsconfig.base.json
+++ b/packages/common/dev/tsconfig.base.json
@@ -1,5 +1,4 @@
 {
-	"include": ["lib", "example", "tests", "vitest.setup.ts"],
 	"compilerOptions": {
 		"module": "ESNext",
 		"moduleResolution": "Node",

--- a/packages/common/focus-trap/tsconfig.json
+++ b/packages/common/focus-trap/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.base.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/react/tsconfig.json
+++ b/packages/common/react/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.react.json",
-	"include": ["lib"],
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/scroll-lock/tsconfig.json
+++ b/packages/common/scroll-lock/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.base.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/solid/tsconfig.json
+++ b/packages/common/solid/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.solid.json",
-	"include": ["lib"],
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/svelte/tsconfig.json
+++ b/packages/common/svelte/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.svelte.json",
-	"include": ["lib"],
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/common/vue/tsconfig.json
+++ b/packages/common/vue/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.vue.json",
-	"include": ["lib"],
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/dialog/core/tsconfig.json
+++ b/packages/dialog/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.base.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
-	},
-	"include": ["lib"]
+	}
 }

--- a/packages/dialog/react/tsconfig.json
+++ b/packages/dialog/react/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.react.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/dialog/solid/tsconfig.json
+++ b/packages/dialog/solid/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.solid.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/dialog/svelte/tsconfig.json
+++ b/packages/dialog/svelte/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.svelte.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}

--- a/packages/dialog/vue/tsconfig.json
+++ b/packages/dialog/vue/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"extends": "@ally-ui/dev/tsconfig.vue.json",
+	"include": ["lib", "example", "tests", "../../common/dev/vitest.setup.ts"],
 	"compilerOptions": {
 		"outDir": "dist"
 	}


### PR DESCRIPTION
If A extends B, the `include` definition is relative to B not A.

I made the mistake of centralizing all `include` definitions in `@ally-ui/dev/tsconfig.base.json` which threw TypeScript Intellisense for a loop.