### PR TITLE
`<Slot/>` with `React.cloneElement`

### DIFF
--- a/packages/common/react/lib/useMultipleRefs.react.tsx
+++ b/packages/common/react/lib/useMultipleRefs.react.tsx
@@ -13,7 +13,7 @@ function setRef<TInstance>(ref: React.Ref<TInstance>, instance: TInstance) {
 	}
 }
 
-function combinedRef<TInstance>(refs: React.Ref<TInstance>[]) {
+export function combinedRef<TInstance>(refs: React.Ref<TInstance>[]) {
 	return (instance: TInstance | null) =>
 		refs.forEach((ref) => setRef(ref, instance));
 }

--- a/packages/dialog/react/example/App.tsx
+++ b/packages/dialog/react/example/App.tsx
@@ -46,36 +46,26 @@ export default function App() {
 						}
 					}}
 				>
-					{(props) => (
-						<section {...props()}>
-							<Dialog.Title ref={titleRef} asChild>
-								{(props) => <h2 {...props}>Edit profile</h2>}
-							</Dialog.Title>
-							<Dialog.Description>
-								Make changes to your profile here. Click save when you're done
-							</Dialog.Description>
-							<fieldset>
-								<label htmlFor="name">Name</label>
-								<input id="name" placeholder="Bryan Lee" />
-							</fieldset>
-							<fieldset>
-								<label htmlFor="username">Username</label>
-								<input id="username" placeholder="@bryanmylee" />
-							</fieldset>
-							<Dialog.Close>Save changes</Dialog.Close>
-							<Dialog.Close asChild>
-								{(props) => (
-									<a
-										{...props({
-											onClick: () => console.log('clicked close'),
-										})}
-									>
-										x
-									</a>
-								)}
-							</Dialog.Close>
-						</section>
-					)}
+					<section>
+						<Dialog.Title ref={titleRef} asChild>
+							<h2>Edit profile</h2>
+						</Dialog.Title>
+						<Dialog.Description>
+							Make changes to your profile here. Click save when you're done
+						</Dialog.Description>
+						<fieldset>
+							<label htmlFor="name">Name</label>
+							<input id="name" placeholder="Bryan Lee" />
+						</fieldset>
+						<fieldset>
+							<label htmlFor="username">Username</label>
+							<input id="username" placeholder="@bryanmylee" />
+						</fieldset>
+						<Dialog.Close>Save changes</Dialog.Close>
+						<Dialog.Close asChild>
+							<a onClick={() => console.log('clicked close')}>x</a>
+						</Dialog.Close>
+					</section>
 				</Dialog.Content>
 			</Dialog.Root>
 			<section>

--- a/packages/dialog/react/lib/DialogClose.react.tsx
+++ b/packages/dialog/react/lib/DialogClose.react.tsx
@@ -1,13 +1,5 @@
-import {
-	DialogCloseModel,
-	type DialogCloseModelAttributes,
-} from '@ally-ui/core-dialog';
-import {
-	Slot,
-	SlottableProps,
-	useMultipleRefs,
-	useRunOnce,
-} from '@ally-ui/react';
+import {DialogCloseModel} from '@ally-ui/core-dialog';
+import {Slot, useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
 import {useDialogRootModel} from './context';
 
@@ -15,13 +7,12 @@ export interface DialogCloseHandlers {
 	onClick: React.MouseEventHandler;
 }
 
-export type DialogCloseProps = SlottableProps<
-	DialogCloseModelAttributes & DialogCloseHandlers,
-	React.DetailedHTMLProps<
-		React.ButtonHTMLAttributes<HTMLButtonElement>,
-		HTMLButtonElement
-	>
->;
+export type DialogCloseProps = React.DetailedHTMLProps<
+	React.ButtonHTMLAttributes<HTMLButtonElement>,
+	HTMLButtonElement
+> & {
+	asChild?: true;
+};
 
 const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
 	(props, forwardedRef) => {
@@ -61,37 +52,18 @@ const DialogClose = React.forwardRef<HTMLButtonElement, DialogCloseProps>(
 			React.MouseEventHandler<HTMLButtonElement>
 		>(
 			(ev) => {
-				if (!props.asChild) {
-					props.onClick?.(ev);
-				}
+				props.onClick?.(ev);
 				component.onClick();
 			},
 			[rootModel],
 		);
 
+		const Comp = props.asChild ? Slot : 'button';
+
 		return (
-			<Slot
-				slotRef={ref}
-				props={props}
-				attributes={{
-					...component.getAttributes(),
-					onClick: handleClick,
-				}}
-				mergeProps={(attributes, userProps) => ({
-					...attributes,
-					...userProps,
-					onClick: (ev) => {
-						userProps.onClick?.(ev);
-						attributes.onClick(ev);
-					},
-				})}
-			>
-				{({ref, children, attributes}) => (
-					<button ref={ref} {...attributes}>
-						{children}
-					</button>
-				)}
-			</Slot>
+			<Comp ref={ref} {...component.getAttributes()} onClick={handleClick}>
+				{props.children}
+			</Comp>
 		);
 	},
 );

--- a/packages/dialog/react/lib/DialogContent.react.tsx
+++ b/packages/dialog/react/lib/DialogContent.react.tsx
@@ -1,11 +1,9 @@
 import {
 	DialogContentModel,
-	type DialogContentModelAttributes,
 	type DialogContentModelOptions,
 } from '@ally-ui/core-dialog';
 import {
 	Slot,
-	SlottableProps,
 	useMultipleRefs,
 	useRunOnce,
 	useSyncedOption,
@@ -17,11 +15,13 @@ import {
 	useDialogRootState,
 } from './context';
 
-export type DialogContentProps = SlottableProps<
-	DialogContentModelAttributes,
-	React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+export type DialogContentProps = React.DetailedHTMLProps<
+	React.HTMLAttributes<HTMLDivElement>,
+	HTMLDivElement
 > &
-	DialogContentModelOptions;
+	DialogContentModelOptions & {
+		asChild?: true;
+	};
 
 const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
 	(
@@ -111,20 +111,14 @@ const DialogContent = React.forwardRef<HTMLElement, DialogContentProps>(
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
+		const Comp = props.asChild ? Slot : 'div';
+
 		return (
 			<>
 				{derivedState.show && (
-					<Slot
-						slotRef={ref}
-						props={props}
-						attributes={component.getAttributes(rootState)}
-					>
-						{({ref, children, attributes}) => (
-							<div ref={ref} {...attributes}>
-								{children}
-							</div>
-						)}
-					</Slot>
+					<Comp ref={ref} {...component.getAttributes(rootState)}>
+						{props.children}
+					</Comp>
 				)}
 			</>
 		);

--- a/packages/dialog/react/lib/DialogDescription.react.tsx
+++ b/packages/dialog/react/lib/DialogDescription.react.tsx
@@ -2,22 +2,16 @@ import {
 	DialogDescriptionModel,
 	type DialogDescriptionModelAttributes,
 } from '@ally-ui/core-dialog';
-import {
-	Slot,
-	SlottableProps,
-	useMultipleRefs,
-	useRunOnce,
-} from '@ally-ui/react';
+import {Slot, useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
 import {useDialogRootModel} from './context';
 
-export type DialogDescriptionProps = SlottableProps<
-	DialogDescriptionModelAttributes,
-	React.DetailedHTMLProps<
-		React.HTMLAttributes<HTMLParagraphElement>,
-		HTMLParagraphElement
-	>
->;
+export type DialogDescriptionProps = React.DetailedHTMLProps<
+	React.HTMLAttributes<HTMLParagraphElement>,
+	HTMLParagraphElement
+> & {
+	asChild?: true;
+};
 
 const DialogDescription = React.forwardRef<HTMLElement, DialogDescriptionProps>(
 	(props, forwardedRef) => {
@@ -55,14 +49,12 @@ const DialogDescription = React.forwardRef<HTMLElement, DialogDescriptionProps>(
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
+		const Comp = props.asChild ? Slot : 'p';
+
 		return (
-			<Slot slotRef={ref} props={props} attributes={component.getAttributes()}>
-				{({ref, attributes, children}) => (
-					<p ref={ref} {...attributes}>
-						{children}
-					</p>
-				)}
-			</Slot>
+			<Comp ref={ref} {...component.getAttributes()}>
+				{props.children}
+			</Comp>
 		);
 	},
 );

--- a/packages/dialog/react/lib/DialogTitle.react.tsx
+++ b/packages/dialog/react/lib/DialogTitle.react.tsx
@@ -2,22 +2,16 @@ import {
 	DialogTitleModel,
 	type DialogTitleModelAttributes,
 } from '@ally-ui/core-dialog';
-import {
-	Slot,
-	SlottableProps,
-	useMultipleRefs,
-	useRunOnce,
-} from '@ally-ui/react';
+import {Slot, useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
 import {useDialogRootModel} from './context';
 
-export type DialogTitleProps = SlottableProps<
-	DialogTitleModelAttributes,
-	React.DetailedHTMLProps<
-		React.HTMLAttributes<HTMLHeadingElement>,
-		HTMLHeadingElement
-	>
->;
+export type DialogTitleProps = React.DetailedHTMLProps<
+	React.HTMLAttributes<HTMLHeadingElement>,
+	HTMLHeadingElement
+> & {
+	asChild?: true;
+};
 
 const DialogTitle = React.forwardRef<HTMLElement, DialogTitleProps>(
 	(props, forwardedRef) => {
@@ -53,14 +47,12 @@ const DialogTitle = React.forwardRef<HTMLElement, DialogTitleProps>(
 		);
 		const ref = useMultipleRefs(bindRef, forwardedRef);
 
+		const Comp = props.asChild ? Slot : 'h1';
+
 		return (
-			<Slot slotRef={ref} props={props} attributes={component.getAttributes()}>
-				{({ref, attributes, children}) => (
-					<h1 ref={ref} {...attributes}>
-						{children}
-					</h1>
-				)}
-			</Slot>
+			<Comp ref={ref} {...component.getAttributes()}>
+				{props.children}
+			</Comp>
 		);
 	},
 );

--- a/packages/dialog/react/lib/DialogTrigger.react.tsx
+++ b/packages/dialog/react/lib/DialogTrigger.react.tsx
@@ -2,12 +2,7 @@ import {
 	DialogTriggerModel,
 	type DialogTriggerModelAttributes,
 } from '@ally-ui/core-dialog';
-import {
-	Slot,
-	useMultipleRefs,
-	useRunOnce,
-	type SlottableProps,
-} from '@ally-ui/react';
+import {Slot, useMultipleRefs, useRunOnce} from '@ally-ui/react';
 import React from 'react';
 import {useDialogRootModel, useDialogRootState} from './context';
 
@@ -15,13 +10,12 @@ export interface DialogTriggerHandlers {
 	onClick: React.MouseEventHandler;
 }
 
-export type DialogTriggerProps = SlottableProps<
-	DialogTriggerModelAttributes & DialogTriggerHandlers,
-	React.DetailedHTMLProps<
-		React.ButtonHTMLAttributes<HTMLButtonElement>,
-		HTMLButtonElement
-	>
->;
+export type DialogTriggerProps = React.DetailedHTMLProps<
+	React.ButtonHTMLAttributes<HTMLButtonElement>,
+	HTMLButtonElement
+> & {
+	asChild?: true;
+};
 
 const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 	(props, forwardedRef) => {
@@ -71,29 +65,16 @@ const DialogTrigger = React.forwardRef<HTMLButtonElement, DialogTriggerProps>(
 			[rootModel],
 		);
 
+		const Comp = props.asChild ? Slot : 'button';
+
 		return (
-			<Slot
-				slotRef={ref}
-				props={props}
-				attributes={{
-					...component.getAttributes(rootState),
-					onClick: handleClick,
-				}}
-				mergeProps={(attributes, userProps) => ({
-					...attributes,
-					...userProps,
-					onClick: (ev) => {
-						userProps.onClick?.(ev);
-						attributes.onClick(ev);
-					},
-				})}
+			<Comp
+				ref={ref}
+				{...component.getAttributes(rootState)}
+				onClick={handleClick}
 			>
-				{({ref, children, attributes}) => (
-					<button ref={ref} {...attributes}>
-						{children}
-					</button>
-				)}
-			</Slot>
+				{props.children}
+			</Comp>
 		);
 	},
 );


### PR DESCRIPTION
Get rid of the need for render prop getters by using React's internal cloneElement system.